### PR TITLE
Refactor footer and nav to make their own calls

### DIFF
--- a/src/components/contexts/SharedDataProvider.tsx
+++ b/src/components/contexts/SharedDataProvider.tsx
@@ -1,0 +1,57 @@
+import React, { createContext, useContext, useState, useEffect } from 'react';
+import { FooterStrapiContent } from '../../data/interfaces/footer/FooterStrapiContent';
+import { NavigationBarStrapiContent } from '../../data/interfaces/navigation-bar/NavigationBarStrapiContent';
+import {
+  getFooterStrapiData,
+  getNavigationBarStrapiData,
+} from '../../api/strapiApi';
+import Loading from '../loading/Loading';
+
+type SharedData = {
+  navigationBarContent?: NavigationBarStrapiContent;
+  footerContent?: FooterStrapiContent;
+};
+
+export const SharedDataContext = createContext<SharedData | null>(null);
+
+export const SharedDataProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const [sharedData, setSharedData] = useState<SharedData>({});
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        setLoading(true);
+        const [navigationBarContent, footerContent] = await Promise.all([
+          getNavigationBarStrapiData(),
+          getFooterStrapiData(),
+        ]);
+        setSharedData({ navigationBarContent, footerContent });
+      } catch (err) {
+        console.error('Error fetching shared data:', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, []);
+
+  if (loading) return <Loading />;
+
+  return (
+    <SharedDataContext.Provider value={sharedData}>
+      {children}
+    </SharedDataContext.Provider>
+  );
+};
+
+export const useSharedData = () => {
+  const context = useContext(SharedDataContext);
+  if (!context) {
+    throw new Error('useSharedData must be used within a SharedDataProvider');
+  }
+  return context;
+};

--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -1,14 +1,13 @@
 import React from 'react';
 import * as Bs from 'react-bootstrap';
-import { FooterStrapiContent } from '../../data/interfaces/footer/FooterStrapiContent';
 import useWindowDimensions from '../../hooks/windowDimensions';
 import './footer.scss';
+import { useSharedData } from '../contexts/SharedDataProvider';
 
-const Footer: React.FC<{ content: FooterStrapiContent }> = ({
-  content: content,
-}) => {
+const Footer: React.FC = () => {
   const { width } = useWindowDimensions();
   const showClass = (): string | boolean => (width <= 992 ? ' active' : false);
+  const { footerContent: content } = useSharedData();
 
   return (
     <section data-testid="footer" className="footer-section">

--- a/src/components/footer/footer.test.tsx
+++ b/src/components/footer/footer.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, Mock, test, vi } from 'vitest';
 import useWindowDimensions from '../../hooks/windowDimensions';
 import Footer from './Footer';
 import FooterFactory from '../../test/factories/strapi/FooterFactory';
+import { SharedDataContext } from '../contexts/SharedDataProvider';
 
 vi.mock('../../hooks/windowDimensions', () => ({
   default: vi.fn(),
@@ -15,9 +16,15 @@ describe('Footer', () => {
     const mockData = new FooterFactory().getMockData();
     (useWindowDimensions as Mock).mockReturnValue({ width: windowWidth });
     render(
-      <MemoryRouter>
-        <Footer content={mockData} />
-      </MemoryRouter>
+      <SharedDataContext.Provider
+        value={{
+          footerContent: mockData,
+        }}
+      >
+        <MemoryRouter>
+          <Footer />
+        </MemoryRouter>
+      </SharedDataContext.Provider>
     );
   };
 

--- a/src/components/navigation-bar/NavigationBar.tsx
+++ b/src/components/navigation-bar/NavigationBar.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
 import * as Bs from 'react-bootstrap';
-import { NavigationBarStrapiContent } from '../../data/interfaces/navigation-bar/NavigationBarStrapiContent';
 import './navigationBar.scss';
+import { useSharedData } from '../contexts/SharedDataProvider';
 
-const NavigationBar: React.FC<{ content: NavigationBarStrapiContent }> = ({
-  content,
-}) => {
+const NavigationBar: React.FC = () => {
+  const { navigationBarContent: content } = useSharedData();
   return (
     <section data-testid="navbar">
       {content && (

--- a/src/components/navigation-bar/navigationBar.test.tsx
+++ b/src/components/navigation-bar/navigationBar.test.tsx
@@ -4,14 +4,21 @@ import { MemoryRouter } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import NavigationBar from './NavigationBar';
 import NavigationBarFactory from '../../test/factories/strapi/NavigationBarFactory';
+import { SharedDataContext } from '../contexts/SharedDataProvider';
 
 describe('NavigationBar', () => {
   beforeEach(() => {
     const mockData = new NavigationBarFactory().getMockData();
     render(
-      <MemoryRouter>
-        <NavigationBar content={mockData} />
-      </MemoryRouter>
+      <SharedDataContext.Provider
+        value={{
+          navigationBarContent: mockData,
+        }}
+      >
+        <MemoryRouter>
+          <NavigationBar />
+        </MemoryRouter>
+      </SharedDataContext.Provider>
     );
   });
 

--- a/src/components/page-wrapper/PageWrapper.tsx
+++ b/src/components/page-wrapper/PageWrapper.tsx
@@ -1,28 +1,20 @@
 import React from 'react';
 import * as Bs from 'react-bootstrap';
-import { FooterStrapiContent } from '../../data/interfaces/footer/FooterStrapiContent';
-import { NavigationBarStrapiContent } from '../../data/interfaces/navigation-bar/NavigationBarStrapiContent';
 import Footer from '../footer/Footer';
 import NavigationBar from '../navigation-bar/NavigationBar';
 
 type Props = {
   children: React.ReactNode;
-  navigationBarStrapiData: NavigationBarStrapiContent;
-  footerStrapiData: FooterStrapiContent;
 };
 
-const PageWrapper: React.FC<Props> = ({
-  children,
-  navigationBarStrapiData,
-  footerStrapiData,
-}) => {
+const PageWrapper: React.FC<Props> = ({ children }) => {
   return (
     <>
-      <NavigationBar content={navigationBarStrapiData} />
+      <NavigationBar />
       <section data-testid="main-content">
         <Bs.Container fluid>{children}</Bs.Container>
       </section>
-      <Footer content={footerStrapiData} />
+      <Footer />
     </>
   );
 };

--- a/src/components/page-wrapper/pageWrapper.test.tsx
+++ b/src/components/page-wrapper/pageWrapper.test.tsx
@@ -14,6 +14,7 @@ import useWindowDimensions from '../../hooks/windowDimensions';
 import PageWrapper from './PageWrapper';
 import NavigationBarFactory from '../../test/factories/strapi/NavigationBarFactory';
 import FooterFactory from '../../test/factories/strapi/FooterFactory';
+import { SharedDataContext } from '../contexts/SharedDataProvider';
 
 vi.mock('../../hooks/windowDimensions', () => ({
   default: vi.fn(),
@@ -26,14 +27,18 @@ describe('PageWrapper', () => {
     (useWindowDimensions as Mock).mockReturnValue({ width: 1024 });
 
     render(
-      <MemoryRouter>
-        <PageWrapper
-          navigationBarStrapiData={navigationMockData}
-          footerStrapiData={footerMockData}
-        >
-          <h1>I am a child</h1>
-        </PageWrapper>
-      </MemoryRouter>
+      <SharedDataContext.Provider
+        value={{
+          navigationBarContent: navigationMockData,
+          footerContent: footerMockData,
+        }}
+      >
+        <MemoryRouter>
+          <PageWrapper>
+            <h1>I am a child</h1>
+          </PageWrapper>
+        </MemoryRouter>
+      </SharedDataContext.Provider>
     );
   });
 

--- a/src/data/types/LoaderData.ts
+++ b/src/data/types/LoaderData.ts
@@ -1,12 +1,8 @@
-import { FooterStrapiContent } from '../interfaces/footer/FooterStrapiContent';
 import { LandingPageStrapiContent } from '../interfaces/landing-page/LandingPageStrapiContent';
-import { NavigationBarStrapiContent } from '../interfaces/navigation-bar/NavigationBarStrapiContent';
 import { OurMissionVisionAndValuesPageStrapiContent } from '../interfaces/our-mission-vision-and-values-page/OurMissionVisionAndValuesPageStrapiContent';
 import { OurTeamPageStrapiContent } from '../interfaces/our-team-page/OurTeamPageStrapiContent';
 
 export type LoaderData = {
-  navigationBarStrapiData: NavigationBarStrapiContent;
-  footerStrapiData: FooterStrapiContent;
   landingPageStrapiData: LandingPageStrapiContent;
   ourMissionVisionAndValuesStrapiData: OurMissionVisionAndValuesPageStrapiContent;
   ourTeamPageStrapiData: OurTeamPageStrapiContent;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,9 +5,12 @@ import { RouterProvider } from 'react-router-dom';
 import Loading from './components/loading/Loading';
 import './index.scss';
 import router from './routes';
+import { SharedDataProvider } from './components/contexts/SharedDataProvider';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <RouterProvider router={router} fallbackElement={<Loading />} />
+    <SharedDataProvider>
+      <RouterProvider router={router} fallbackElement={<Loading />} />
+    </SharedDataProvider>
   </StrictMode>
 );

--- a/src/pages/landing-page/LandingPage.tsx
+++ b/src/pages/landing-page/LandingPage.tsx
@@ -12,16 +12,12 @@ import LandingPagePaymentSection from '../../components/landing-page/landing-pag
 import LandingPageQuoteCarousel from '../../components/landing-page/landing-page-quote-section/landing-page-quote-carousel/LandingPageQuoteCarousel';
 
 const LandingPage: React.FC = () => {
-  const { navigationBarStrapiData, footerStrapiData, landingPageStrapiData } =
-    useLoaderData() as LoaderData;
+  const { landingPageStrapiData } = useLoaderData() as LoaderData;
   const { width } = useWindowDimensions();
   const showMobileView: boolean = width <= 992 ? true : false;
 
   return (
-    <PageWrapper
-      navigationBarStrapiData={navigationBarStrapiData}
-      footerStrapiData={footerStrapiData}
-    >
+    <PageWrapper>
       <Bs.Row className="mb-5">
         <Bs.Col>
           {showMobileView ? (

--- a/src/pages/landing-page/landingPage.test.tsx
+++ b/src/pages/landing-page/landingPage.test.tsx
@@ -15,6 +15,7 @@ import navigationBarFactory from '../../test/factories/strapi/NavigationBarFacto
 import useWindowDimensions from '../../hooks/windowDimensions';
 import LandingPageFactory from '../../test/factories/strapi/LandingPageFactory';
 import FooterFactory from '../../test/factories/strapi/FooterFactory';
+import { SharedDataContext } from '../../components/contexts/SharedDataProvider';
 
 vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual('react-router-dom');
@@ -30,19 +31,27 @@ vi.mock('../../hooks/windowDimensions', () => ({
 
 describe('LandingPage', () => {
   const mockLoaderData = {
-    navigationBarStrapiData: new navigationBarFactory().getMockData(),
-    footerStrapiData: new FooterFactory().getMockData(),
     landingPageStrapiData: new LandingPageFactory().getMockData(),
   };
+
+  const navigationBarStrapiData = new navigationBarFactory().getMockData();
+  const footerStrapiData = new FooterFactory().getMockData();
 
   const setup = async (windowWidth: number = 1024) => {
     (useLoaderData as Mock).mockReturnValue(mockLoaderData);
     (useWindowDimensions as Mock).mockReturnValue({ windowWidth: windowWidth });
 
     render(
-      <MemoryRouter>
-        <LandingPage />
-      </MemoryRouter>
+      <SharedDataContext.Provider
+        value={{
+          navigationBarContent: navigationBarStrapiData,
+          footerContent: footerStrapiData,
+        }}
+      >
+        <MemoryRouter>
+          <LandingPage />
+        </MemoryRouter>
+      </SharedDataContext.Provider>
     );
   };
 

--- a/src/pages/our-mission-vision-and-values-page/OurMissionVisionAndValuesPage.tsx
+++ b/src/pages/our-mission-vision-and-values-page/OurMissionVisionAndValuesPage.tsx
@@ -8,17 +8,10 @@ import OurMissionVisionAndValuesPageVisionSection from '../../components/our-mis
 import OurMissionVisionAndValuesPageValuesSection from '../../components/our-mission-vision-and-values-page/our-mission-vision-and-values-page-values-section/OurMissionVisionAndValuesPageValuesSection';
 
 const OurMissionVisionAndValuesPage: React.FC = () => {
-  const {
-    navigationBarStrapiData,
-    footerStrapiData,
-    ourMissionVisionAndValuesStrapiData,
-  } = useLoaderData() as LoaderData;
+  const { ourMissionVisionAndValuesStrapiData } = useLoaderData() as LoaderData;
 
   return (
-    <PageWrapper
-      navigationBarStrapiData={navigationBarStrapiData}
-      footerStrapiData={footerStrapiData}
-    >
+    <PageWrapper>
       <Bs.Row className="mt-5 mb-2">
         <Bs.Col className="text-center">
           <h1 className="fs-1 fw-bold">

--- a/src/pages/our-mission-vision-and-values-page/ourMissionVisionAndValuesPage.test.tsx
+++ b/src/pages/our-mission-vision-and-values-page/ourMissionVisionAndValuesPage.test.tsx
@@ -14,6 +14,7 @@ import navigationBarFactory from '../../test/factories/strapi/NavigationBarFacto
 import FooterFactory from '../../test/factories/strapi/FooterFactory';
 import OurMissionVisionAndValuesPageFactory from '../../test/factories/strapi/OurMissionVisionAndValuesPageFactory';
 import OurMissionVisionAndValuesPage from './OurMissionVisionAndValuesPage';
+import { SharedDataContext } from '../../components/contexts/SharedDataProvider';
 
 vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual('react-router-dom');
@@ -25,18 +26,26 @@ vi.mock('react-router-dom', async () => {
 
 describe('OurMissionVisionAndValuesPage', () => {
   const mockLoaderData = {
-    navigationBarStrapiData: new navigationBarFactory().getMockData(),
-    footerStrapiData: new FooterFactory().getMockData(),
     ourMissionVisionAndValuesStrapiData:
       new OurMissionVisionAndValuesPageFactory().getMockData(),
   };
 
+  const navigationBarStrapiData = new navigationBarFactory().getMockData();
+  const footerStrapiData = new FooterFactory().getMockData();
+
   const setup = async () => {
     (useLoaderData as Mock).mockReturnValue(mockLoaderData);
     render(
-      <MemoryRouter>
-        <OurMissionVisionAndValuesPage />
-      </MemoryRouter>
+      <SharedDataContext.Provider
+        value={{
+          navigationBarContent: navigationBarStrapiData,
+          footerContent: footerStrapiData,
+        }}
+      >
+        <MemoryRouter>
+          <OurMissionVisionAndValuesPage />
+        </MemoryRouter>
+      </SharedDataContext.Provider>
     );
   };
 

--- a/src/pages/our-team-page/OurTeamPage.tsx
+++ b/src/pages/our-team-page/OurTeamPage.tsx
@@ -6,14 +6,10 @@ import { useLoaderData } from 'react-router-dom';
 import OurTeamPageDepartmentSection from '../../components/our-team-page/OurTeamPageDepartmentSection';
 
 const OurTeamPage: React.FC = () => {
-  const { navigationBarStrapiData, footerStrapiData, ourTeamPageStrapiData } =
-    useLoaderData() as LoaderData;
+  const { ourTeamPageStrapiData } = useLoaderData() as LoaderData;
 
   return (
-    <PageWrapper
-      navigationBarStrapiData={navigationBarStrapiData}
-      footerStrapiData={footerStrapiData}
-    >
+    <PageWrapper>
       <Bs.Row className="mt-5 mb-2">
         <Bs.Col className="text-center">
           <h1 data-testid="our-team-page-title" className="fs-1 fw-bold">

--- a/src/pages/our-team-page/ourTeamPage.test.tsx
+++ b/src/pages/our-team-page/ourTeamPage.test.tsx
@@ -14,6 +14,7 @@ import navigationBarFactory from '../../test/factories/strapi/NavigationBarFacto
 import FooterFactory from '../../test/factories/strapi/FooterFactory';
 import OurTeamPageFactory from '../../test/factories/strapi/OurTeamPageFactory';
 import OurTeamPage from './OurTeamPage';
+import { SharedDataContext } from '../../components/contexts/SharedDataProvider';
 
 vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual('react-router-dom');
@@ -25,17 +26,25 @@ vi.mock('react-router-dom', async () => {
 
 describe('OurTeamPage', () => {
   const mockLoaderData = {
-    navigationBarStrapiData: new navigationBarFactory().getMockData(),
-    footerStrapiData: new FooterFactory().getMockData(),
     ourTeamPageStrapiData: new OurTeamPageFactory().getMockData(),
   };
+
+  const navigationBarStrapiData = new navigationBarFactory().getMockData();
+  const footerStrapiData = new FooterFactory().getMockData();
 
   const setup = async () => {
     (useLoaderData as Mock).mockReturnValue(mockLoaderData);
     render(
-      <MemoryRouter>
-        <OurTeamPage />
-      </MemoryRouter>
+      <SharedDataContext.Provider
+        value={{
+          navigationBarContent: navigationBarStrapiData,
+          footerContent: footerStrapiData,
+        }}
+      >
+        <MemoryRouter>
+          <OurTeamPage />
+        </MemoryRouter>
+      </SharedDataContext.Provider>
     );
   };
 

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import { createBrowserRouter } from 'react-router-dom';
 import {
-  getFooterStrapiData,
   getLandingPageStrapiData,
-  getNavigationBarStrapiData,
   getOurMissionVisionAndValuesPageStrapiData,
   getOurTeamPageStrapiData,
 } from './api/strapiApi';
@@ -16,35 +14,20 @@ const router = createBrowserRouter([
     path: '/',
     element: <LandingPage />,
     loader: async () => {
-      const [navigationBarStrapiData, footerStrapiData, landingPageStrapiData] =
-        await Promise.all([
-          getNavigationBarStrapiData(),
-          getFooterStrapiData(),
-          getLandingPageStrapiData(),
-        ]);
+      const landingPageStrapiData = await getLandingPageStrapiData();
       return {
-        navigationBarStrapiData,
-        footerStrapiData,
         landingPageStrapiData,
       };
     },
   },
+
   {
     path: '/our-mission-vision-and-values',
     element: <OurMissionVisionAndValuesPage />,
     loader: async () => {
-      const [
-        navigationBarStrapiData,
-        footerStrapiData,
-        ourMissionVisionAndValuesStrapiData,
-      ] = await Promise.all([
-        getNavigationBarStrapiData(),
-        getFooterStrapiData(),
-        getOurMissionVisionAndValuesPageStrapiData(),
-      ]);
+      const ourMissionVisionAndValuesStrapiData =
+        await getOurMissionVisionAndValuesPageStrapiData();
       return {
-        navigationBarStrapiData,
-        footerStrapiData,
         ourMissionVisionAndValuesStrapiData,
       };
     },
@@ -53,15 +36,8 @@ const router = createBrowserRouter([
     path: '/our-team',
     element: <OurTeamPage />,
     loader: async () => {
-      const [navigationBarStrapiData, footerStrapiData, ourTeamPageStrapiData] =
-        await Promise.all([
-          getNavigationBarStrapiData(),
-          getFooterStrapiData(),
-          getOurTeamPageStrapiData(),
-        ]);
+      const ourTeamPageStrapiData = await getOurTeamPageStrapiData();
       return {
-        navigationBarStrapiData,
-        footerStrapiData,
         ourTeamPageStrapiData,
       };
     },


### PR DESCRIPTION
# Context

- Currently everytime you navigate to a page a call is made to the footer and navbar which seems very redundant as the content will change very very rarely. As a result we need to move out this functionality out of route fetching. Additionally the content is passed down into the pageWrapper which feels unnecessary. 

## Changes proposed in this PR

- Move Navbar and Footer to use shared global context
