### PR TITLE
Introduce loading spinner on home page for smooth load times

### DIFF
--- a/cypress/e2e/components/src/components/footer.cy.js
+++ b/cypress/e2e/components/src/components/footer.cy.js
@@ -21,11 +21,6 @@ describe('Footer', () => {
   it('should load footer and verify all elements are present and functioning', () => {
     cy.get('[data-testid="footer"]').should('be.visible');
 
-    cy.get('[data-testid="footer-image"]').should('be.visible');
-    cy.get('[data-testid="footer-image"]')
-      .should('have.attr', 'src')
-      .and('not.be.empty');
-
     cy.get('.footer-image-caption').should('be.visible');
 
     cy.get('[data-testid="footer-body"]').should('be.visible');

--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -26,6 +26,7 @@ const Footer: React.FC = () => {
                 <Bs.Row>
                   <Bs.Col>
                     <Bs.Image
+                      loading="lazy"
                       data-testid="footer-image"
                       className="footer-image img-fluid"
                       src={content.image.data.attributes.url}
@@ -101,6 +102,7 @@ const Footer: React.FC = () => {
                   >
                     {content.socialMediaLinks.iconLinks.map((iconLink) => (
                       <Bs.Image
+                        loading="lazy"
                         data-testid="social-media-icon"
                         key={iconLink.id}
                         className={`social-media-icon ${'ms-4' + showClass()} me-4`}
@@ -131,6 +133,7 @@ const Footer: React.FC = () => {
                   <Bs.Col>
                     <p>
                       <Bs.Image
+                        loading="lazy"
                         className="me-1 mb-1"
                         alt={
                           content.contactInformation.icon.data.attributes

--- a/src/components/landing-page/landing-page-image-card/desktop/LandingPageImageCardDesktop.tsx
+++ b/src/components/landing-page/landing-page-image-card/desktop/LandingPageImageCardDesktop.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import * as Bs from 'react-bootstrap';
 import './landingPageImageCardDesktop.scss';
 import { LandingImage } from '../../../../data/interfaces/landing-page/LandingPageStrapiContent';
@@ -8,30 +8,49 @@ type Props = {
 };
 
 const LandingPageImageCardDesktop: React.FC<Props> = ({ landingImage }) => {
-  return (
-    <Bs.Card
-      data-testid="landing-image-card-desktop"
-      className="text-white landing-image-card"
-    >
-      <Bs.Card.Img
-        className="landing-image-card-image"
-        src={landingImage.image.data.attributes.url}
-        alt={landingImage.image.data.attributes.alternativeText}
-      />
+  const [imageLoaded, setImageLoaded] = useState(false);
 
-      <Bs.Card.ImgOverlay className="d-flex align-items-end">
-        <Bs.Row>
-          <Bs.Col xl="6" className="mb-5 ms-5">
-            <Bs.Card.Title className="mb-3 landing-image-card-title">
-              {landingImage.title}
-            </Bs.Card.Title>
-            <Bs.Card.Text className="fs-3">
-              {landingImage.subTitle}
-            </Bs.Card.Text>
-          </Bs.Col>
-        </Bs.Row>
-      </Bs.Card.ImgOverlay>
-    </Bs.Card>
+  return (
+    <Bs.Row>
+      <Bs.Col className="d-flex justify-content-center">
+        <Bs.Card
+          data-testid="landing-image-card-desktop"
+          className="text-white landing-image-card"
+        >
+          {!imageLoaded && (
+            <Bs.Row>
+              <Bs.Col className="d-flex justify-content-center">
+                <Bs.Spinner
+                  className="landing-image-card-loading-spinner"
+                  animation="grow"
+                  variant="dark"
+                />
+              </Bs.Col>
+            </Bs.Row>
+          )}
+          <Bs.Card.Img
+            className={`landing-image-card-image ${imageLoaded ? '' : 'd-none'}`}
+            src={landingImage.image.data.attributes.url}
+            alt={landingImage.image.data.attributes.alternativeText}
+            onLoad={() => setImageLoaded(true)}
+          />
+          {imageLoaded && (
+            <Bs.Card.ImgOverlay className="d-flex align-items-end">
+              <Bs.Row>
+                <Bs.Col xs="6" className="mb-5 ms-5">
+                  <Bs.Card.Title className="mb-3 landing-image-card-title">
+                    {landingImage.title}
+                  </Bs.Card.Title>
+                  <Bs.Card.Text className="fs-3">
+                    {landingImage.subTitle}
+                  </Bs.Card.Text>
+                </Bs.Col>
+              </Bs.Row>
+            </Bs.Card.ImgOverlay>
+          )}
+        </Bs.Card>
+      </Bs.Col>
+    </Bs.Row>
   );
 };
 

--- a/src/components/landing-page/landing-page-image-card/desktop/landingPageImageCardDesktop.scss
+++ b/src/components/landing-page/landing-page-image-card/desktop/landingPageImageCardDesktop.scss
@@ -1,6 +1,13 @@
 .landing-image-card {
   border-radius: 50px;
-  margin-bottom: 10vh;
+  margin-top: 2vh;
+  margin-bottom: 5vh;
+  width: 150vh;
+}
+
+.landing-image-card-loading-spinner {
+  margin-top: 250px;
+  margin-bottom: 250px;
 }
 
 .landing-image-card-image {
@@ -8,6 +15,6 @@
 }
 
 .landing-image-card-title {
-  font-size: 3vw;
+  font-size: 3em;
   font-weight: 600;
 }

--- a/src/components/landing-page/landing-page-image-card/mobile/LandingPageCardMobile.tsx
+++ b/src/components/landing-page/landing-page-image-card/mobile/LandingPageCardMobile.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import * as Bs from 'react-bootstrap';
 import './landingPageCardMobile.scss';
 import { LandingImage } from '../../../../data/interfaces/landing-page/LandingPageStrapiContent';
@@ -8,6 +8,8 @@ type Props = {
 };
 
 const LandingPageImageCardMobile: React.FC<Props> = ({ landingImage }) => {
+  const [imageLoaded, setImageLoaded] = useState(false);
+
   return (
     <Bs.Row className="mt-3" data-testid="landing-image-card-mobile">
       <Bs.Col className="text-center">
@@ -23,10 +25,20 @@ const LandingPageImageCardMobile: React.FC<Props> = ({ landingImage }) => {
         </Bs.Row>
         <Bs.Row>
           <Bs.Col className="d-flex justify-content-center">
+            {!imageLoaded && (
+              <Bs.Spinner
+                className="landing-image-card-loading-spinner-mobile"
+                animation="grow"
+                variant="dark"
+              />
+            )}
             <img
-              className="landing-image-card-image-mobile"
+              className={`landing-image-card-image-mobile ${
+                imageLoaded ? '' : 'd-none'
+              }`}
               src={landingImage.image.data.attributes.url}
               alt={landingImage.image.data.attributes.alternativeText}
+              onLoad={() => setImageLoaded(true)}
             />
           </Bs.Col>
         </Bs.Row>

--- a/src/components/landing-page/landing-page-quote-section/landing-page-quote-carousel-card/LandingPageQuoteCarouselCard.tsx
+++ b/src/components/landing-page/landing-page-quote-section/landing-page-quote-carousel-card/LandingPageQuoteCarouselCard.tsx
@@ -18,6 +18,7 @@ const LandingPageQuoteCarouselCard: React.FC<Props> = ({ card, quoteIcon }) => {
       <Bs.Row>
         <Bs.Col>
           <Bs.Image
+            loading="lazy"
             fluid
             data-testid="quote-carousel-card-icon"
             className="mb-3 quote-carousel-card-icon"

--- a/src/components/landing-page/landing-page-speciality-section/landing-page-speciality-carousel-card/LandingPageSpecialityCarouselCard.tsx
+++ b/src/components/landing-page/landing-page-speciality-section/landing-page-speciality-carousel-card/LandingPageSpecialityCarouselCard.tsx
@@ -34,6 +34,7 @@ const LandingPageSpecialityCarouselCard: React.FC<Props> = ({ card }) => {
                   >
                     {card.link.linkString}
                     <Bs.Image
+                      loading="lazy"
                       data-testid="speciality-carousel-card-description-image"
                       className="ms-2 mb-2"
                       src={card.linkIcon.data.attributes.url}


### PR DESCRIPTION
# Context

- The Landing Card on the Landing Page tends to load slightly slower than the  rest of the page and as a result is quite aesthetically displeasing. As a caching system may be out of scope for this small site a loader will solve some of the problem

## Changes proposed in this PR

- Add Landing Card Loader spinner.
