### PR TITLE
Create stat template page

### DIFF
--- a/cypress/e2e/components/src/components/statTemplatePage.cy.js
+++ b/cypress/e2e/components/src/components/statTemplatePage.cy.js
@@ -1,0 +1,37 @@
+describe('Stat Template Page', () => {
+  beforeEach(() => {
+    cy.intercept('GET', '**/api/navigation-bar*', {
+      fixture: 'navigationBarStrapiResponse.json',
+    }).as('getNavigationBarStrapiData');
+
+    cy.intercept('GET', '**/api/footer*', {
+      fixture: 'footerStrapiResponse.json',
+    }).as('getFooterStrapiData');
+
+    cy.intercept('GET', '**/api/our-work-sub-pages/*', {
+      fixture: 'statTemplatePageStrapiResponse.json',
+    }).as('getTrainingAndAdvocacyPageStrapiData');
+
+    cy.visit('/training-and-advocacy');
+
+    cy.wait('@getNavigationBarStrapiData');
+    cy.wait('@getFooterStrapiData');
+    cy.wait('@getTrainingAndAdvocacyPageStrapiData');
+  });
+
+  it('should load a template stat page and verify all elements are present and functioning', () => {
+    cy.get('[data-testid="navbar"]').should('be.visible');
+
+    cy.get('[data-testid="landing-card-desktop"]').should('be.visible');
+    cy.get('[data-testid="stat-template-page-quote-section"]').should(
+      'be.visible'
+    );
+    cy.get('[data-testid="stat-template-page-metric"]').should(
+      'have.length',
+      2
+    );
+    cy.get('[data-testid="stat-template-page-free-text"]').should('be.visible');
+
+    cy.get('[data-testid="footer"]').should('be.visible');
+  });
+});

--- a/fixtures/ourWorkSubPagesStrapiResponse.json
+++ b/fixtures/ourWorkSubPagesStrapiResponse.json
@@ -1,0 +1,54 @@
+{
+  "data": {
+    "id": 1,
+    "attributes": {
+      "freeText": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+      "landingImage": {
+        "id": 2,
+        "title": "Training and Advocacy",
+        "image": {
+          "data": {
+            "id": 8,
+            "attributes": {
+              "name": "about_us_landing_image_53ef9337e9.svg",
+              "alternativeText": null,
+              "caption": null,
+              "width": 1344,
+              "height": 450,
+              "formats": null,
+              "hash": "about_us_landing_image_53ef9337e9_428dc79a0e",
+              "ext": ".svg",
+              "mime": "image/svg+xml",
+              "size": 2411.35,
+              "url": "https://strapi-dr-s3-media-bucket.s3",
+              "previewUrl": null,
+              "provider": "aws-s3",
+              "provider_metadata": null,
+              "createdAt": "2025-01-19T13:48:19.507Z",
+              "updatedAt": "2025-01-19T13:48:19.507Z",
+              "isUrlSigned": true
+            }
+          }
+        }
+      },
+      "quote": {
+        "id": 2,
+        "author": "Ollie",
+        "body": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+      },
+      "metrics": [
+        {
+          "id": 3,
+          "value": "100",
+          "valueDescription": "sd fdg dgfds "
+        },
+        {
+          "id": 4,
+          "value": "0",
+          "valueDescription": "dfgfdg fdg fsg"
+        }
+      ]
+    }
+  },
+  "meta": {}
+}

--- a/fixtures/statTemplatePageStrapiResponse.json
+++ b/fixtures/statTemplatePageStrapiResponse.json
@@ -11,8 +11,8 @@
             "id": 8,
             "attributes": {
               "name": "about_us_landing_image_53ef9337e9.svg",
-              "alternativeText": null,
-              "caption": null,
+              "alternativeText": "anything you want",
+              "caption": "anything you want",
               "width": 1344,
               "height": 450,
               "formats": null,

--- a/src/api/strapiApi.tsx
+++ b/src/api/strapiApi.tsx
@@ -10,6 +10,8 @@ import { AboutUsPageStrapiContent } from '../data/interfaces/about-us-page/About
 import { OurWorkPageStrapiContent } from '../data/interfaces/our-work-page/OurWorkPageStrapiContent';
 import { GetInvolvedPageStrapiContent } from '../data/interfaces/get-involved-page/GetInvolvedPageStrapiContent';
 import { DonatePageStrapiContent } from '../data/interfaces/donate-page/DonatePageStrapiContent';
+import { StatTemplatePageStrapiContent } from '../data/interfaces/stat-template-page/StatTemplatePageStrapiContent';
+import { OurWorkSubPages } from '../data/enums/OurWorkSubPages';
 
 export async function getNavigationBarStrapiData(): Promise<NavigationBarStrapiContent> {
   const query = buildStrapiEndpointQuery([
@@ -122,4 +124,16 @@ export async function getDonatePageStrapiData(): Promise<DonatePageStrapiContent
     'paymentSection.paymentOptionIcon',
   ]);
   return fetchStrapiData('donate-page', query);
+}
+
+export async function getTrainingAndAdvocacyPageStrapiData(): Promise<StatTemplatePageStrapiContent> {
+  const query = buildStrapiEndpointQuery([
+    'landingImage.image',
+    'quote',
+    'metrics',
+  ]);
+  return fetchStrapiData(
+    `our-work-sub-pages/${OurWorkSubPages.TrainingAndAdvocacy}`,
+    query
+  );
 }

--- a/src/components/stat-template-page/stat-template-page-metric/statTemplatePageMetric.scss
+++ b/src/components/stat-template-page/stat-template-page-metric/statTemplatePageMetric.scss
@@ -1,0 +1,3 @@
+.stat-template-page-metric-value {
+  border-bottom: 10px var(--primary) solid;
+}

--- a/src/components/stat-template-page/stat-template-page-metric/statTemplatePageMetric.test.tsx
+++ b/src/components/stat-template-page/stat-template-page-metric/statTemplatePageMetric.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import StatTemplatePageMetric from './statTemplatePageMetric';
+import StatTemplatePageFactory from '../../../test/factories/strapi/StatTemplatePageFactory';
+
+describe('StatTemplatePageMetric', () => {
+  const setup = async () => {
+    const statTemplatePageFactory = new StatTemplatePageFactory();
+    const mockData = statTemplatePageFactory.getMockData();
+    render(
+      <MemoryRouter>
+        <StatTemplatePageMetric metricData={mockData.metrics[0]} />
+      </MemoryRouter>
+    );
+  };
+
+  beforeEach(async () => {
+    await setup();
+  });
+
+  describe('render elements', async () => {
+    test('should render the stat-template metric value after data is loaded', async () => {
+      await waitFor(() => {
+        expect(
+          screen.getByTestId('stat-template-page-metric-value')
+        ).toBeInTheDocument();
+      });
+    });
+
+    test('should render the stat-template metric description after data is loaded', async () => {
+      await waitFor(() => {
+        expect(
+          screen.getByTestId('stat-template-page-metric-description')
+        ).toBeInTheDocument();
+      });
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+});

--- a/src/components/stat-template-page/stat-template-page-metric/statTemplatePageMetric.tsx
+++ b/src/components/stat-template-page/stat-template-page-metric/statTemplatePageMetric.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Metric } from '../../../data/interfaces/stat-template-page/StatTemplatePageStrapiContent';
+import './statTemplatePageMetric.scss';
+
+type Props = {
+  metricData: Metric;
+};
+
+const StatTemplatePageMetric: React.FC<Props> = ({ metricData }) => {
+  return (
+    <div data-testid="stat-template-page-metric" className="m-xl-5">
+      <p
+        data-testid="stat-template-page-metric-value"
+        className="fs-1 fw-bolder stat-template-page-metric-value"
+      >
+        {metricData.value}
+      </p>
+      <p data-testid="stat-template-page-metric-description" className="fs-4">
+        {metricData.valueDescription}
+      </p>
+    </div>
+  );
+};
+
+export default StatTemplatePageMetric;

--- a/src/components/stat-template-page/stat-template-page-quote-section/statTemplatePageQuoteSection.scss
+++ b/src/components/stat-template-page/stat-template-page-quote-section/statTemplatePageQuoteSection.scss
@@ -1,0 +1,30 @@
+.stat-template-page-quote-section-body {
+  border-radius: 25px;
+  background-color: var(--background-light);
+}
+
+.stat-template-page-quote-section-wrapper {
+  position: relative;
+
+  &::before {
+    content: '';
+    position: absolute;
+    height: 18vw;
+    width: 8vw;
+    background-color: var(--primary);
+    z-index: -1;
+    border-radius: 25px;
+    top: 20%;
+    left: 60%;
+
+    @media (max-width: 2000px) {
+      height: 21vw;
+      width: 10vw;
+    }
+
+    @media (max-width: 1799px) {
+      height: 0;
+      width: 0;
+    }
+  }
+}

--- a/src/components/stat-template-page/stat-template-page-quote-section/statTemplatePageQuoteSection.test.tsx
+++ b/src/components/stat-template-page/stat-template-page-quote-section/statTemplatePageQuoteSection.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import StatTemplatePageQuoteSection from './statTemplatePageQuoteSection';
+import StatTemplatePageFactory from '../../../test/factories/strapi/StatTemplatePageFactory';
+
+describe('StatTemplatePageQuoteSection', () => {
+  const setup = async () => {
+    const statTemplatePageFactory = new StatTemplatePageFactory();
+    const mockData = statTemplatePageFactory.getMockData();
+    render(
+      <MemoryRouter>
+        <StatTemplatePageQuoteSection quoteData={mockData.quote} />
+      </MemoryRouter>
+    );
+  };
+
+  beforeEach(async () => {
+    await setup();
+  });
+
+  describe('render elements', async () => {
+    test('should render the stat template quote body after data is loaded', async () => {
+      await waitFor(() => {
+        expect(
+          screen.getByTestId('stat-template-page-quote-body')
+        ).toBeInTheDocument();
+      });
+    });
+
+    test('should render the stat template quote author after data is loaded', async () => {
+      await waitFor(() => {
+        expect(
+          screen.getByTestId('stat-template-page-quote-author')
+        ).toBeInTheDocument();
+      });
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+});

--- a/src/components/stat-template-page/stat-template-page-quote-section/statTemplatePageQuoteSection.tsx
+++ b/src/components/stat-template-page/stat-template-page-quote-section/statTemplatePageQuoteSection.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { Quote } from '../../../data/interfaces/stat-template-page/StatTemplatePageStrapiContent';
+import './statTemplatePageQuoteSection.scss';
+
+type Props = {
+  quoteData: Quote;
+};
+
+const StatTemplatePageQuoteSection: React.FC<Props> = ({ quoteData }) => {
+  return (
+    <div
+      data-testid="stat-template-page-quote-section"
+      className="stat-template-page-quote-section-wrapper mb-5"
+    >
+      <div className="p-4 stat-template-page-quote-section-body">
+        <p
+          data-testid="stat-template-page-quote-body"
+          className="fs-2 fw-bolder"
+        >
+          {quoteData.body}
+        </p>
+        <p
+          data-testid="stat-template-page-quote-author"
+          className="fs-3 fst-italic"
+        >
+          {quoteData.author}
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default StatTemplatePageQuoteSection;

--- a/src/data/enums/OurWorkSubPages.ts
+++ b/src/data/enums/OurWorkSubPages.ts
@@ -1,0 +1,3 @@
+export enum OurWorkSubPages {
+  TrainingAndAdvocacy = '1',
+}

--- a/src/data/interfaces/stat-template-page/StatTemplatePageStrapiContent.ts
+++ b/src/data/interfaces/stat-template-page/StatTemplatePageStrapiContent.ts
@@ -1,0 +1,18 @@
+import { LandingCard } from '../landing-card/LandingCard';
+
+export interface StatTemplatePageStrapiContent {
+  landingImage: LandingCard;
+  quote: Quote;
+  metrics: Array<Metric>;
+  freeText: string;
+}
+
+export interface Quote {
+  body: string;
+  author: string;
+}
+
+export interface Metric {
+  value: string;
+  valueDescription: string;
+}

--- a/src/data/types/LoaderData.ts
+++ b/src/data/types/LoaderData.ts
@@ -15,5 +15,5 @@ export type LoaderData = {
   aboutUsPageStrapiData: AboutUsPageStrapiContent;
   ourWorkPageStrapiData: OurWorkPageStrapiContent;
   getInvolvedPageStrapiData: GetInvolvedPageStrapiContent;
-  data: StatTemplatePageStrapiContent;
+  statTemplatePageStrapiData: StatTemplatePageStrapiContent;
 };

--- a/src/data/types/LoaderData.ts
+++ b/src/data/types/LoaderData.ts
@@ -5,6 +5,7 @@ import { OurDonorsPageStrapiContent } from '../interfaces/our-donor-page/OurDono
 import { OurMissionVisionAndValuesPageStrapiContent } from '../interfaces/our-mission-vision-and-values-page/OurMissionVisionAndValuesPageStrapiContent';
 import { OurTeamPageStrapiContent } from '../interfaces/our-team-page/OurTeamPageStrapiContent';
 import { OurWorkPageStrapiContent } from '../interfaces/our-work-page/OurWorkPageStrapiContent';
+import { StatTemplatePageStrapiContent } from '../interfaces/stat-template-page/StatTemplatePageStrapiContent';
 
 export type LoaderData = {
   landingPageStrapiData: LandingPageStrapiContent;
@@ -14,4 +15,5 @@ export type LoaderData = {
   aboutUsPageStrapiData: AboutUsPageStrapiContent;
   ourWorkPageStrapiData: OurWorkPageStrapiContent;
   getInvolvedPageStrapiData: GetInvolvedPageStrapiContent;
+  data: StatTemplatePageStrapiContent;
 };

--- a/src/pages/stat-template-page/StatTemplatePage.tsx
+++ b/src/pages/stat-template-page/StatTemplatePage.tsx
@@ -9,27 +9,33 @@ import StatTemplatePageQuoteSection from '../../components/stat-template-page/st
 import StatTemplatePageMetric from '../../components/stat-template-page/stat-template-page-metric/statTemplatePageMetric';
 
 const StatTemplatePage: React.FC = () => {
-  const { data } = useLoaderData() as LoaderData;
+  const { statTemplatePageStrapiData } = useLoaderData() as LoaderData;
   return (
     <PageWrapper>
       <Row>
         <Col>
           <div className="d-none d-sm-block mb-5">
-            <LandingCardDesktop landingCard={data.landingImage} />
+            <LandingCardDesktop
+              landingCard={statTemplatePageStrapiData.landingImage}
+            />
           </div>
           <div className="d-sm-none">
-            <LandingCardMobile landingCard={data.landingImage} />
+            <LandingCardMobile
+              landingCard={statTemplatePageStrapiData.landingImage}
+            />
           </div>
         </Col>
       </Row>
       <Container className="mb-5">
         <Row className="gx-5 mb-5">
           <Col xl="4">
-            <StatTemplatePageQuoteSection quoteData={data.quote} />
+            <StatTemplatePageQuoteSection
+              quoteData={statTemplatePageStrapiData.quote}
+            />
           </Col>
           <Col xl={{ span: 7, offset: 1 }} sm="12">
             <Row>
-              {data.metrics.map((metric, index) => (
+              {statTemplatePageStrapiData.metrics.map((metric, index) => (
                 <Col key={index} xl="6" sm="12">
                   <StatTemplatePageMetric metricData={metric} />
                 </Col>

--- a/src/pages/stat-template-page/StatTemplatePage.tsx
+++ b/src/pages/stat-template-page/StatTemplatePage.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import PageWrapper from '../../components/page-wrapper/PageWrapper';
+import { Col, Container, Row } from 'react-bootstrap';
+import { useLoaderData } from 'react-router-dom';
+import { LoaderData } from '../../data/types/LoaderData';
+import LandingCardDesktop from '../../components/landing-card/desktop/LandingCardDesktop';
+import LandingCardMobile from '../../components/landing-card/mobile/landingCardMobile';
+import OurWorkPageQuoteSection from '../../components/our-work-page/our-work-page-quote-section/OurWorkPageQuoteSection';
+import OurWorkPageMetric from '../../components/our-work-page/our-work-page-metric/OurWorkPageMetric';
+
+const StatTemplatePage: React.FC = () => {
+  const { data } = useLoaderData() as LoaderData;
+  return (
+    <PageWrapper>
+      <Row>
+        <Col>
+          <div className="d-none d-sm-block mb-5">
+            <LandingCardDesktop landingCard={data.landingImage} />
+          </div>
+          <div className="d-sm-none">
+            <LandingCardMobile landingCard={data.landingImage} />
+          </div>
+        </Col>
+      </Row>
+      <Container className="mb-5">
+        <Row className="gx-5 mb-5">
+          <Col xl="4">
+            <OurWorkPageQuoteSection quoteData={data.quote} />
+          </Col>
+          <Col xl={{ span: 7, offset: 1 }} sm="12">
+            <Row>
+              {data.metrics.map((metric, index) => (
+                <Col key={index} xl="6" sm="12">
+                  <OurWorkPageMetric metricData={metric} />
+                </Col>
+              ))}
+            </Row>
+          </Col>
+        </Row>
+      </Container>
+    </PageWrapper>
+  );
+};
+
+export default StatTemplatePage;

--- a/src/pages/stat-template-page/StatTemplatePage.tsx
+++ b/src/pages/stat-template-page/StatTemplatePage.tsx
@@ -44,6 +44,16 @@ const StatTemplatePage: React.FC = () => {
           </Col>
         </Row>
       </Container>
+      <Row>
+        <Col>
+          <p
+            data-testid="stat-template-page-free-text"
+            className="fs-4 px-5 text-center"
+          >
+            {statTemplatePageStrapiData.freeText}
+          </p>
+        </Col>
+      </Row>
     </PageWrapper>
   );
 };

--- a/src/pages/stat-template-page/StatTemplatePage.tsx
+++ b/src/pages/stat-template-page/StatTemplatePage.tsx
@@ -5,8 +5,8 @@ import { useLoaderData } from 'react-router-dom';
 import { LoaderData } from '../../data/types/LoaderData';
 import LandingCardDesktop from '../../components/landing-card/desktop/LandingCardDesktop';
 import LandingCardMobile from '../../components/landing-card/mobile/landingCardMobile';
-import OurWorkPageQuoteSection from '../../components/our-work-page/our-work-page-quote-section/OurWorkPageQuoteSection';
-import OurWorkPageMetric from '../../components/our-work-page/our-work-page-metric/OurWorkPageMetric';
+import StatTemplatePageQuoteSection from '../../components/stat-template-page/stat-template-page-quote-section/statTemplatePageQuoteSection';
+import StatTemplatePageMetric from '../../components/stat-template-page/stat-template-page-metric/statTemplatePageMetric';
 
 const StatTemplatePage: React.FC = () => {
   const { data } = useLoaderData() as LoaderData;
@@ -25,13 +25,13 @@ const StatTemplatePage: React.FC = () => {
       <Container className="mb-5">
         <Row className="gx-5 mb-5">
           <Col xl="4">
-            <OurWorkPageQuoteSection quoteData={data.quote} />
+            <StatTemplatePageQuoteSection quoteData={data.quote} />
           </Col>
           <Col xl={{ span: 7, offset: 1 }} sm="12">
             <Row>
               {data.metrics.map((metric, index) => (
                 <Col key={index} xl="6" sm="12">
-                  <OurWorkPageMetric metricData={metric} />
+                  <StatTemplatePageMetric metricData={metric} />
                 </Col>
               ))}
             </Row>

--- a/src/pages/stat-template-page/statTemplatePage.test.tsx
+++ b/src/pages/stat-template-page/statTemplatePage.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter, useLoaderData } from 'react-router-dom';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  Mock,
+  test,
+  vi,
+} from 'vitest';
+import navigationBarFactory from '../../test/factories/strapi/NavigationBarFactory';
+import FooterFactory from '../../test/factories/strapi/FooterFactory';
+import { SharedDataContext } from '../../contexts/SharedDataProvider';
+import StatTemplatePageFactory from '../../test/factories/strapi/StatTemplatePageFactory';
+import StatTemplatePage from './StatTemplatePage';
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useLoaderData: vi.fn(),
+  };
+});
+
+describe('StatTemplatePage', () => {
+  const mockLoaderData = {
+    statTemplatePageStrapiData: new StatTemplatePageFactory().getMockData(),
+  };
+
+  const navigationBarStrapiData = new navigationBarFactory().getMockData();
+  const footerStrapiData = new FooterFactory().getMockData();
+
+  const setup = async () => {
+    (useLoaderData as Mock).mockReturnValue(mockLoaderData);
+    render(
+      <SharedDataContext.Provider
+        value={{
+          navigationBarContent: navigationBarStrapiData,
+          footerContent: footerStrapiData,
+        }}
+      >
+        <MemoryRouter>
+          <StatTemplatePage />
+        </MemoryRouter>
+      </SharedDataContext.Provider>
+    );
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('render elements', () => {
+    test('should render the stat template page title when data is loaded', async () => {
+      await setup();
+      await waitFor(() => {
+        expect(screen.getByTestId('landing-title-desktop')).toBeInTheDocument();
+      });
+    });
+
+    test('should render the stat template page quote section when data is loaded', async () => {
+      await setup();
+      await waitFor(() => {
+        expect(
+          screen.getByTestId('stat-template-page-quote-section')
+        ).toBeInTheDocument();
+      });
+    });
+
+    test('should render the stat template metrics when data is loaded', async () => {
+      await setup();
+      await waitFor(() => {
+        expect(screen.getAllByTestId('stat-template-page-metric').length).toBe(
+          2
+        );
+      });
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+});

--- a/src/pages/stat-template-page/statTemplatePage.test.tsx
+++ b/src/pages/stat-template-page/statTemplatePage.test.tsx
@@ -77,6 +77,15 @@ describe('StatTemplatePage', () => {
         );
       });
     });
+
+    test('should render the stat template free text when data is loaded', async () => {
+      await setup();
+      await waitFor(() => {
+        expect(
+          screen.getByTestId('stat-template-page-free-text')
+        ).toBeInTheDocument();
+      });
+    });
   });
 
   afterEach(() => {

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -108,9 +108,10 @@ const router = createBrowserRouter([
     path: '/training-and-advocacy',
     element: <StatTemplatePage />,
     loader: async () => {
-      const data = await getTrainingAndAdvocacyPageStrapiData();
+      const statTemplatePageStrapiData =
+        await getTrainingAndAdvocacyPageStrapiData();
       return {
-        data,
+        statTemplatePageStrapiData,
       };
     },
   },

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -9,6 +9,7 @@ import {
   getOurMissionVisionAndValuesPageStrapiData,
   getOurTeamPageStrapiData,
   getOurWorkPageStrapiData,
+  getTrainingAndAdvocacyPageStrapiData,
 } from './api/strapiApi';
 import LandingPage from './pages/landing-page/LandingPage';
 import OurMissionVisionAndValuesPage from './pages/our-mission-vision-and-values-page/OurMissionVisionAndValuesPage';
@@ -18,6 +19,7 @@ import AboutUsPage from './pages/about-us-page/AboutUsPage';
 import OurWorkPage from './pages/our-work-page/OurWorkPage';
 import GetInvolvedPage from './pages/get-involved-page/GetInvolvedPage';
 import DonatePage from './pages/donate-page/DonatePage';
+import StatTemplatePage from './pages/stat-template-page/StatTemplatePage';
 
 const router = createBrowserRouter([
   {
@@ -99,6 +101,16 @@ const router = createBrowserRouter([
       const donatePageStrapiData = await getDonatePageStrapiData();
       return {
         donatePageStrapiData,
+      };
+    },
+  },
+  {
+    path: '/training-and-advocacy',
+    element: <StatTemplatePage />,
+    loader: async () => {
+      const data = await getTrainingAndAdvocacyPageStrapiData();
+      return {
+        data,
       };
     },
   },

--- a/src/test/factories/strapi/StatTemplatePageFactory.ts
+++ b/src/test/factories/strapi/StatTemplatePageFactory.ts
@@ -1,0 +1,14 @@
+import StatTemplatePageStrapiResponse from '../../../../fixtures/statTemplatePageStrapiResponse.json';
+import { StatTemplatePageStrapiContent } from '../../../data/interfaces/stat-template-page/StatTemplatePageStrapiContent';
+import BaseFactory from '../BaseFactory';
+
+class StatTemplatePageFactory extends BaseFactory<StatTemplatePageStrapiContent> {
+  constructor() {
+    super(
+      StatTemplatePageStrapiResponse,
+      `${import.meta.env.VITE_BASE_URL}/api/stat-template-page/1?populate[0]=landingImage.image&populate[1]=quote&populate[2]=metrics`
+    );
+  }
+}
+
+export default StatTemplatePageFactory;


### PR DESCRIPTION
# Context

- Development of the stat template page. Dream Renewables has requested a few more pages in the style of the our work page which has required us to template a page with stats. This page will be a collection type in the CMS however we want this page to have better url's than just the page id's so each page will have a route specified where as this will be done programmatically for the blog

## Changes proposed in this PR

- Create stat template Page
