### PR TITLE
Create remaining our work sub pages

### DIFF
--- a/cypress/e2e/components/src/components/ourWorkSubPage.cy.js
+++ b/cypress/e2e/components/src/components/ourWorkSubPage.cy.js
@@ -10,13 +10,13 @@ describe('Stat Template Page', () => {
 
     cy.intercept('GET', '**/api/our-work-sub-pages/*', {
       fixture: 'statTemplatePageStrapiResponse.json',
-    }).as('getTrainingAndAdvocacyPageStrapiData');
+    }).as('getOurWorkSubPageStrapiData');
 
-    cy.visit('/training-and-advocacy');
+    cy.visit('/our-work/training-and-advocacy');
 
     cy.wait('@getNavigationBarStrapiData');
     cy.wait('@getFooterStrapiData');
-    cy.wait('@getTrainingAndAdvocacyPageStrapiData');
+    cy.wait('@getOurWorkSubPageStrapiData');
   });
 
   it('should load a template stat page and verify all elements are present and functioning', () => {

--- a/src/api/strapiApi.test.ts
+++ b/src/api/strapiApi.test.ts
@@ -11,6 +11,7 @@ import {
   getOurMissionVisionAndValuesPageStrapiData,
   getOurTeamPageStrapiData,
   getOurWorkPageStrapiData,
+  getOurWorkSubPageStrapiData,
 } from './strapiApi';
 import LandingPageFactory from '../test/factories/strapi/LandingPageFactory';
 import NavigationBarFactory from '../test/factories/strapi/NavigationBarFactory';
@@ -22,6 +23,8 @@ import AboutUsPageFactory from '../test/factories/strapi/AboutUsPageFactory';
 import OurWorkPageFactory from '../test/factories/strapi/OurWorkPageFactory';
 import GetInvolvedPageFactory from '../test/factories/strapi/GetInvolvedPageFactory';
 import DonatePageFactory from '../test/factories/strapi/DonatePageFactory';
+import StatTemplatePageFactory from '../test/factories/strapi/StatTemplatePageFactory';
+import { OurWorkSubPages } from '../data/enums/OurWorkSubPages';
 
 interface MockData<T> {
   data: {
@@ -260,5 +263,29 @@ describe('strapiApi', () => {
     //     'Request failed with status code 500'
     //   );
     // });
+  });
+
+  describe('getOurWorkSubPageStrapiData', () => {
+    test('should get a our work sub page data successfully', async () => {
+      const statTemplatePageFactory = new StatTemplatePageFactory();
+      const mockResponse = statTemplatePageFactory.getMockResponse();
+      const apiUrl = statTemplatePageFactory.getApiUrl();
+      await setup(apiUrl, mockResponse, 200);
+
+      const response = await getOurWorkSubPageStrapiData(
+        OurWorkSubPages.TrainingAndAdvocacy
+      );
+      expect(response).toEqual(mockResponse.data.attributes);
+    });
+
+    test('should handle errors when get a our work sub page data returns a 500', async () => {
+      const statTemplatePageFactory = new StatTemplatePageFactory();
+      const emptyMockData = statTemplatePageFactory.getEmptyMockData();
+      const apiUrl = statTemplatePageFactory.getApiUrl();
+      await setup(apiUrl, emptyMockData, 500);
+      await expect(
+        getOurWorkSubPageStrapiData(OurWorkSubPages.TrainingAndAdvocacy)
+      ).rejects.toThrow('Request failed with status code 500');
+    });
   });
 });

--- a/src/api/strapiApi.tsx
+++ b/src/api/strapiApi.tsx
@@ -126,14 +126,13 @@ export async function getDonatePageStrapiData(): Promise<DonatePageStrapiContent
   return fetchStrapiData('donate-page', query);
 }
 
-export async function getTrainingAndAdvocacyPageStrapiData(): Promise<StatTemplatePageStrapiContent> {
+export async function getOurWorkSubPageStrapiData(
+  pageId: OurWorkSubPages
+): Promise<StatTemplatePageStrapiContent> {
   const query = buildStrapiEndpointQuery([
     'landingImage.image',
     'quote',
     'metrics',
   ]);
-  return fetchStrapiData(
-    `our-work-sub-pages/${OurWorkSubPages.TrainingAndAdvocacy}`,
-    query
-  );
+  return fetchStrapiData(`our-work-sub-pages/${pageId}`, query);
 }

--- a/src/components/stat-template-page/stat-template-page-quote-section/statTemplatePageQuoteSection.tsx
+++ b/src/components/stat-template-page/stat-template-page-quote-section/statTemplatePageQuoteSection.tsx
@@ -12,7 +12,7 @@ const StatTemplatePageQuoteSection: React.FC<Props> = ({ quoteData }) => {
       data-testid="stat-template-page-quote-section"
       className="stat-template-page-quote-section-wrapper mb-5"
     >
-      <div className="p-4 stat-template-page-quote-section-body">
+      <div className="p-4 stat-template-page-quote-section-body text-center text-sm-center">
         <p
           data-testid="stat-template-page-quote-body"
           className="fs-2 fw-bolder"

--- a/src/data/enums/OurWorkSubPages.ts
+++ b/src/data/enums/OurWorkSubPages.ts
@@ -1,4 +1,8 @@
 export enum OurWorkSubPages {
   TrainingAndAdvocacy = '1',
   Entrepreneurship = '2',
+  SolarPoweredSchools = '3',
+  SolarPoweredIrrigation = '4',
+  SolarPoweredClinics = '5',
+  CleanerCooking = '6',
 }

--- a/src/data/enums/OurWorkSubPages.ts
+++ b/src/data/enums/OurWorkSubPages.ts
@@ -1,3 +1,4 @@
 export enum OurWorkSubPages {
   TrainingAndAdvocacy = '1',
+  Entrepreneurship = '2',
 }

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -128,6 +128,54 @@ const router = createBrowserRouter([
       };
     },
   },
+  {
+    path: '/our-work/solar-powered-schools',
+    element: <StatTemplatePage />,
+    loader: async () => {
+      const statTemplatePageStrapiData = await getOurWorkSubPageStrapiData(
+        OurWorkSubPages.SolarPoweredSchools
+      );
+      return {
+        statTemplatePageStrapiData,
+      };
+    },
+  },
+  {
+    path: '/our-work/solar-powered-irrigation',
+    element: <StatTemplatePage />,
+    loader: async () => {
+      const statTemplatePageStrapiData = await getOurWorkSubPageStrapiData(
+        OurWorkSubPages.SolarPoweredIrrigation
+      );
+      return {
+        statTemplatePageStrapiData,
+      };
+    },
+  },
+  {
+    path: '/our-work/solar-powered-clinics',
+    element: <StatTemplatePage />,
+    loader: async () => {
+      const statTemplatePageStrapiData = await getOurWorkSubPageStrapiData(
+        OurWorkSubPages.SolarPoweredClinics
+      );
+      return {
+        statTemplatePageStrapiData,
+      };
+    },
+  },
+  {
+    path: '/our-work/cleaner-cooking',
+    element: <StatTemplatePage />,
+    loader: async () => {
+      const statTemplatePageStrapiData = await getOurWorkSubPageStrapiData(
+        OurWorkSubPages.CleanerCooking
+      );
+      return {
+        statTemplatePageStrapiData,
+      };
+    },
+  },
 ]);
 
 export default router;

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -9,7 +9,7 @@ import {
   getOurMissionVisionAndValuesPageStrapiData,
   getOurTeamPageStrapiData,
   getOurWorkPageStrapiData,
-  getTrainingAndAdvocacyPageStrapiData,
+  getOurWorkSubPageStrapiData,
 } from './api/strapiApi';
 import LandingPage from './pages/landing-page/LandingPage';
 import OurMissionVisionAndValuesPage from './pages/our-mission-vision-and-values-page/OurMissionVisionAndValuesPage';
@@ -20,6 +20,7 @@ import OurWorkPage from './pages/our-work-page/OurWorkPage';
 import GetInvolvedPage from './pages/get-involved-page/GetInvolvedPage';
 import DonatePage from './pages/donate-page/DonatePage';
 import StatTemplatePage from './pages/stat-template-page/StatTemplatePage';
+import { OurWorkSubPages } from './data/enums/OurWorkSubPages';
 
 const router = createBrowserRouter([
   {
@@ -32,7 +33,6 @@ const router = createBrowserRouter([
       };
     },
   },
-
   {
     path: '/our-mission-vision-and-values',
     element: <OurMissionVisionAndValuesPage />,
@@ -75,16 +75,6 @@ const router = createBrowserRouter([
     },
   },
   {
-    path: '/our-work',
-    element: <OurWorkPage />,
-    loader: async () => {
-      const ourWorkPageStrapiData = await getOurWorkPageStrapiData();
-      return {
-        ourWorkPageStrapiData,
-      };
-    },
-  },
-  {
     path: '/get-involved',
     element: <GetInvolvedPage />,
     loader: async () => {
@@ -105,11 +95,34 @@ const router = createBrowserRouter([
     },
   },
   {
-    path: '/training-and-advocacy',
+    path: '/our-work',
+    element: <OurWorkPage />,
+    loader: async () => {
+      const ourWorkPageStrapiData = await getOurWorkPageStrapiData();
+      return {
+        ourWorkPageStrapiData,
+      };
+    },
+  },
+  {
+    path: '/our-work/training-and-advocacy',
     element: <StatTemplatePage />,
     loader: async () => {
-      const statTemplatePageStrapiData =
-        await getTrainingAndAdvocacyPageStrapiData();
+      const statTemplatePageStrapiData = await getOurWorkSubPageStrapiData(
+        OurWorkSubPages.TrainingAndAdvocacy
+      );
+      return {
+        statTemplatePageStrapiData,
+      };
+    },
+  },
+  {
+    path: '/our-work/entrepreneurship',
+    element: <StatTemplatePage />,
+    loader: async () => {
+      const statTemplatePageStrapiData = await getOurWorkSubPageStrapiData(
+        OurWorkSubPages.Entrepreneurship
+      );
       return {
         statTemplatePageStrapiData,
       };

--- a/src/test/factories/strapi/StatTemplatePageFactory.ts
+++ b/src/test/factories/strapi/StatTemplatePageFactory.ts
@@ -1,4 +1,5 @@
 import StatTemplatePageStrapiResponse from '../../../../fixtures/statTemplatePageStrapiResponse.json';
+import { OurWorkSubPages } from '../../../data/enums/OurWorkSubPages';
 import { StatTemplatePageStrapiContent } from '../../../data/interfaces/stat-template-page/StatTemplatePageStrapiContent';
 import BaseFactory from '../BaseFactory';
 
@@ -6,7 +7,7 @@ class StatTemplatePageFactory extends BaseFactory<StatTemplatePageStrapiContent>
   constructor() {
     super(
       StatTemplatePageStrapiResponse,
-      `${import.meta.env.VITE_BASE_URL}/api/stat-template-page/1?populate[0]=landingImage.image&populate[1]=quote&populate[2]=metrics`
+      `${import.meta.env.VITE_BASE_URL}/api/our-work-sub-pages/${OurWorkSubPages.TrainingAndAdvocacy}?populate[0]=landingImage.image&populate[1]=quote&populate[2]=metrics`
     );
   }
 }


### PR DESCRIPTION
# Context

- With a stat template page created in this [PR](https://github.com/OAMPC/DreamRenewablesFrontend/pull/30) it should be very easy to quickly create more of these pages. This is an implementation for the our work sub pages. The urls for this have been hardcoded which means in order to create more of these pages coding is required which is inherently problematic should DR want to create more. A future PR should address this so its more dynamic.

## Changes proposed in this PR

- create a generalise get our work sub page api call
- create new page routes
