### PR TITLE
Use cms routing for our work sub pages

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+VITE_STRAPI_API_TOKEN=i_am_obtained_from_your_local_strapi_server
+VITE_BASE_URL=http://localhost:1337
+VITE_BASE_APP_URL=http://localhost:5173
+VITE_STRIPE_PUBLISHABLE_KEY=i_am_obtained_from_your_test_stripe_settings

--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ This project uses [Husky](https://typicode.github.io/husky/) and [lint-staged](h
 
 1. Clone the repo to your chosen directory
 2. Install dependencies `npm i`
-3. Create a .env file in the project root directory with the command: `touch .env` In order to obtain an API token for strapi to run the project locally you must run the [strapi](https://github.com/OAMPC/DreamRenewablesCms) project and [create one](https://docs.strapi.io/user-docs/settings/API-tokens).
+3. Create a .env file in the project root directory with the command e.g in bash: `touch .env` In order to obtain an API token for strapi to run the project locally you must run the [strapi](https://github.com/OAMPC/DreamRenewablesCms) project and [create one](https://docs.strapi.io/user-docs/settings/API-tokens). The .env.example provides some guidance on what is required, reach out to a project admin for help if required.
 4. The pre-commit file _.husky/pre-commit_ should contain the following line only: `npx lint-staged`
    - The subfolder _.husky/_\_ is required and should _not_ be committed by default
-5. Ensure the pre-commit file is executable: `chmod +x .husky/pre-commit`
+5. Ensure the pre-commit file is executable e.g in bash: `chmod +x .husky/pre-commit`
 
 ## Usage
 
@@ -50,6 +50,7 @@ To run the application you must ensure you've followed the setup steps
   - Ensure you're in the root directory
   - spin up the application: `npm run dev`
   - To run tests `npm run test`
+  - To run end to end tests `npm run e2e`. You will need the application running for this.
 
 ## Continuous Integration, Development and Deployment
 
@@ -61,7 +62,8 @@ This project uses a combination of technologies for Ci/Cd currently these are [G
 
 ### Related Repositories
 
-| Name                                                                                      | Description                                                   |
-| :---------------------------------------------------------------------------------------- | :------------------------------------------------------------ |
-| [Dream Renewables Cms](https://github.com/OAMPC/DreamRenewablesCms)                       | The Content Management System for this web application        |
-| [Dream Renewables Infrastructure](https://github.com/OAMPC/DreamRenewablesInfrastructure) | The Terraform for this web applications required architecture |
+| Name                                                                                      | Description                                                                 |
+| :---------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------- |
+| [Dream Renewables Cms](https://github.com/OAMPC/DreamRenewablesCms)                       | The Content Management System for this web application                      |
+| [Dream Renewables Infrastructure](https://github.com/OAMPC/DreamRenewablesInfrastructure) | The Terraform for this web applications required architecture               |
+| [Dream Renewables Serverless](https://github.com/OAMPC/DreamRenewableServerless)          | The Serverless function code for this web applications AWS lambda functions |

--- a/cypress/e2e/components/src/components/aboutUsPage.cy.js
+++ b/cypress/e2e/components/src/components/aboutUsPage.cy.js
@@ -1,17 +1,5 @@
 describe('About Us Page', () => {
   beforeEach(() => {
-    cy.intercept('GET', '**/api/navigation-bar*', {
-      fixture: 'navigationBarStrapiResponse.json',
-    }).as('getNavigationBarStrapiData');
-
-    cy.intercept('GET', '**/api/footer*', {
-      fixture: 'footerStrapiResponse.json',
-    }).as('getFooterStrapiData');
-
-    cy.intercept('GET', '**/api/our-work-sub-pages*', {
-      fixture: 'ourWorkSubPagesStrapiResponse.json',
-    }).as('getOurWorkSubPagesStrapiData');
-
     cy.intercept('GET', '**/api/about-us-page*', {
       fixture: 'aboutUsPageStrapiResponse.json',
     }).as('aboutUsPageStrapiData');

--- a/cypress/e2e/components/src/components/aboutUsPage.cy.js
+++ b/cypress/e2e/components/src/components/aboutUsPage.cy.js
@@ -8,6 +8,10 @@ describe('About Us Page', () => {
       fixture: 'footerStrapiResponse.json',
     }).as('getFooterStrapiData');
 
+    cy.intercept('GET', '**/api/our-work-sub-pages*', {
+      fixture: 'ourWorkSubPagesStrapiResponse.json',
+    }).as('getOurWorkSubPagesStrapiData');
+
     cy.intercept('GET', '**/api/about-us-page*', {
       fixture: 'aboutUsPageStrapiResponse.json',
     }).as('aboutUsPageStrapiData');
@@ -16,6 +20,7 @@ describe('About Us Page', () => {
 
     cy.wait('@getNavigationBarStrapiData');
     cy.wait('@getFooterStrapiData');
+    cy.wait('@getOurWorkSubPagesStrapiData');
     cy.wait('@aboutUsPageStrapiData');
   });
 

--- a/cypress/e2e/components/src/components/donatePage.cy.js
+++ b/cypress/e2e/components/src/components/donatePage.cy.js
@@ -1,17 +1,5 @@
 describe('Donate Page', () => {
   beforeEach(() => {
-    cy.intercept('GET', '**/api/navigation-bar*', {
-      fixture: 'navigationBarStrapiResponse.json',
-    }).as('getNavigationBarStrapiData');
-
-    cy.intercept('GET', '**/api/footer*', {
-      fixture: 'footerStrapiResponse.json',
-    }).as('getFooterStrapiData');
-
-    cy.intercept('GET', '**/api/our-work-sub-pages*', {
-      fixture: 'ourWorkSubPagesStrapiResponse.json',
-    }).as('getOurWorkSubPagesStrapiData');
-
     cy.intercept('GET', '**/api/donate-page*', {
       fixture: 'donatePageStrapiResponse.json',
     }).as('donatePageStrapiData');

--- a/cypress/e2e/components/src/components/donatePage.cy.js
+++ b/cypress/e2e/components/src/components/donatePage.cy.js
@@ -8,6 +8,10 @@ describe('Donate Page', () => {
       fixture: 'footerStrapiResponse.json',
     }).as('getFooterStrapiData');
 
+    cy.intercept('GET', '**/api/our-work-sub-pages*', {
+      fixture: 'ourWorkSubPagesStrapiResponse.json',
+    }).as('getOurWorkSubPagesStrapiData');
+
     cy.intercept('GET', '**/api/donate-page*', {
       fixture: 'donatePageStrapiResponse.json',
     }).as('donatePageStrapiData');
@@ -16,6 +20,7 @@ describe('Donate Page', () => {
 
     cy.wait('@getNavigationBarStrapiData');
     cy.wait('@getFooterStrapiData');
+    cy.wait('@getOurWorkSubPagesStrapiData');
     cy.wait('@donatePageStrapiData');
   });
 

--- a/cypress/e2e/components/src/components/footer.cy.js
+++ b/cypress/e2e/components/src/components/footer.cy.js
@@ -8,6 +8,10 @@ describe('Footer', () => {
       fixture: 'footerStrapiResponse.json',
     }).as('getFooterStrapiData');
 
+    cy.intercept('GET', '**/api/our-work-sub-pages*', {
+      fixture: 'ourWorkSubPagesStrapiResponse.json',
+    }).as('getOurWorkSubPagesStrapiData');
+
     cy.intercept('GET', '**/api/landing-page*', {
       fixture: 'landingPageStrapiResponse.json',
     }).as('getLandingPageStrapiData');
@@ -15,6 +19,7 @@ describe('Footer', () => {
     cy.visit('/');
     cy.wait('@getNavigationBarStrapiData');
     cy.wait('@getFooterStrapiData');
+    cy.wait('@getOurWorkSubPagesStrapiData');
     cy.wait('@getLandingPageStrapiData');
   });
 

--- a/cypress/e2e/components/src/components/footer.cy.js
+++ b/cypress/e2e/components/src/components/footer.cy.js
@@ -1,17 +1,5 @@
 describe('Footer', () => {
   beforeEach(() => {
-    cy.intercept('GET', '**/api/navigation-bar*', {
-      fixture: 'navigationBarStrapiResponse.json',
-    }).as('getNavigationBarStrapiData');
-
-    cy.intercept('GET', '**/api/footer*', {
-      fixture: 'footerStrapiResponse.json',
-    }).as('getFooterStrapiData');
-
-    cy.intercept('GET', '**/api/our-work-sub-pages*', {
-      fixture: 'ourWorkSubPagesStrapiResponse.json',
-    }).as('getOurWorkSubPagesStrapiData');
-
     cy.intercept('GET', '**/api/landing-page*', {
       fixture: 'landingPageStrapiResponse.json',
     }).as('getLandingPageStrapiData');

--- a/cypress/e2e/components/src/components/getInvolvedPage.cy.js
+++ b/cypress/e2e/components/src/components/getInvolvedPage.cy.js
@@ -8,6 +8,10 @@ describe('Get Involved Page', () => {
       fixture: 'footerStrapiResponse.json',
     }).as('getFooterStrapiData');
 
+    cy.intercept('GET', '**/api/our-work-sub-pages*', {
+      fixture: 'ourWorkSubPagesStrapiResponse.json',
+    }).as('getOurWorkSubPagesStrapiData');
+
     cy.intercept('GET', '**/api/get-involved-page*', {
       fixture: 'getInvolvedPageStrapiResponse.json',
     }).as('getInvolvedPageStrapiData');
@@ -16,6 +20,7 @@ describe('Get Involved Page', () => {
 
     cy.wait('@getNavigationBarStrapiData');
     cy.wait('@getFooterStrapiData');
+    cy.wait('@getOurWorkSubPagesStrapiData');
     cy.wait('@getInvolvedPageStrapiData');
   });
 

--- a/cypress/e2e/components/src/components/getInvolvedPage.cy.js
+++ b/cypress/e2e/components/src/components/getInvolvedPage.cy.js
@@ -1,17 +1,5 @@
 describe('Get Involved Page', () => {
   beforeEach(() => {
-    cy.intercept('GET', '**/api/navigation-bar*', {
-      fixture: 'navigationBarStrapiResponse.json',
-    }).as('getNavigationBarStrapiData');
-
-    cy.intercept('GET', '**/api/footer*', {
-      fixture: 'footerStrapiResponse.json',
-    }).as('getFooterStrapiData');
-
-    cy.intercept('GET', '**/api/our-work-sub-pages*', {
-      fixture: 'ourWorkSubPagesStrapiResponse.json',
-    }).as('getOurWorkSubPagesStrapiData');
-
     cy.intercept('GET', '**/api/get-involved-page*', {
       fixture: 'getInvolvedPageStrapiResponse.json',
     }).as('getInvolvedPageStrapiData');

--- a/cypress/e2e/components/src/components/landingPage.cy.js
+++ b/cypress/e2e/components/src/components/landingPage.cy.js
@@ -8,6 +8,10 @@ describe('Landing Page', () => {
       fixture: 'footerStrapiResponse.json',
     }).as('getFooterStrapiData');
 
+    cy.intercept('GET', '**/api/our-work-sub-pages*', {
+      fixture: 'ourWorkSubPagesStrapiResponse.json',
+    }).as('getOurWorkSubPagesStrapiData');
+
     cy.intercept('GET', '**/api/landing-page*', {
       fixture: 'landingPageStrapiResponse.json',
     }).as('getLandingPageStrapiData');
@@ -15,6 +19,7 @@ describe('Landing Page', () => {
     cy.visit('/');
     cy.wait('@getNavigationBarStrapiData');
     cy.wait('@getFooterStrapiData');
+    cy.wait('@getOurWorkSubPagesStrapiData');
     cy.wait('@getLandingPageStrapiData');
   });
 

--- a/cypress/e2e/components/src/components/landingPage.cy.js
+++ b/cypress/e2e/components/src/components/landingPage.cy.js
@@ -1,17 +1,5 @@
 describe('Landing Page', () => {
   beforeEach(() => {
-    cy.intercept('GET', '**/api/navigation-bar*', {
-      fixture: 'navigationBarStrapiResponse.json',
-    }).as('getNavigationBarStrapiData');
-
-    cy.intercept('GET', '**/api/footer*', {
-      fixture: 'footerStrapiResponse.json',
-    }).as('getFooterStrapiData');
-
-    cy.intercept('GET', '**/api/our-work-sub-pages*', {
-      fixture: 'ourWorkSubPagesStrapiResponse.json',
-    }).as('getOurWorkSubPagesStrapiData');
-
     cy.intercept('GET', '**/api/landing-page*', {
       fixture: 'landingPageStrapiResponse.json',
     }).as('getLandingPageStrapiData');

--- a/cypress/e2e/components/src/components/navigationBar.cy.js
+++ b/cypress/e2e/components/src/components/navigationBar.cy.js
@@ -1,22 +1,11 @@
 describe('NavigationBar', () => {
   beforeEach(() => {
-    cy.intercept('GET', '**/api/navigation-bar*', {
-      fixture: 'navigationBarStrapiResponse.json',
-    }).as('getNavigationBarStrapiData');
-
-    cy.intercept('GET', '**/api/footer*', {
-      fixture: 'footerStrapiResponse.json',
-    }).as('getFooterStrapiData');
-
-    cy.intercept('GET', '**/api/our-work-sub-pages*', {
-      fixture: 'ourWorkSubPagesStrapiResponse.json',
-    }).as('getOurWorkSubPagesStrapiData');
-
     cy.intercept('GET', '**/api/landing-page*', {
       fixture: 'landingPageStrapiResponse.json',
     }).as('getLandingPageStrapiData');
 
     cy.visit('/');
+
     cy.wait('@getNavigationBarStrapiData');
     cy.wait('@getFooterStrapiData');
     cy.wait('@getOurWorkSubPagesStrapiData');

--- a/cypress/e2e/components/src/components/navigationBar.cy.js
+++ b/cypress/e2e/components/src/components/navigationBar.cy.js
@@ -8,6 +8,10 @@ describe('NavigationBar', () => {
       fixture: 'footerStrapiResponse.json',
     }).as('getFooterStrapiData');
 
+    cy.intercept('GET', '**/api/our-work-sub-pages*', {
+      fixture: 'ourWorkSubPagesStrapiResponse.json',
+    }).as('getOurWorkSubPagesStrapiData');
+
     cy.intercept('GET', '**/api/landing-page*', {
       fixture: 'landingPageStrapiResponse.json',
     }).as('getLandingPageStrapiData');
@@ -15,6 +19,7 @@ describe('NavigationBar', () => {
     cy.visit('/');
     cy.wait('@getNavigationBarStrapiData');
     cy.wait('@getFooterStrapiData');
+    cy.wait('@getOurWorkSubPagesStrapiData');
     cy.wait('@getLandingPageStrapiData');
   });
 

--- a/cypress/e2e/components/src/components/ourDonorsPage.cy.js
+++ b/cypress/e2e/components/src/components/ourDonorsPage.cy.js
@@ -8,6 +8,10 @@ describe('Our Donors Page', () => {
       fixture: 'footerStrapiResponse.json',
     }).as('getFooterStrapiData');
 
+    cy.intercept('GET', '**/api/our-work-sub-pages*', {
+      fixture: 'ourWorkSubPagesStrapiResponse.json',
+    }).as('getOurWorkSubPagesStrapiData');
+
     cy.intercept('GET', '**/api/our-donors-page*', {
       fixture: 'ourDonorsPageStrapiResponse.json',
     }).as('getOurDonorsPageStrapiData');
@@ -16,6 +20,7 @@ describe('Our Donors Page', () => {
 
     cy.wait('@getNavigationBarStrapiData');
     cy.wait('@getFooterStrapiData');
+    cy.wait('@getOurWorkSubPagesStrapiData');
     cy.wait('@getOurDonorsPageStrapiData');
   });
 

--- a/cypress/e2e/components/src/components/ourDonorsPage.cy.js
+++ b/cypress/e2e/components/src/components/ourDonorsPage.cy.js
@@ -1,17 +1,5 @@
 describe('Our Donors Page', () => {
   beforeEach(() => {
-    cy.intercept('GET', '**/api/navigation-bar*', {
-      fixture: 'navigationBarStrapiResponse.json',
-    }).as('getNavigationBarStrapiData');
-
-    cy.intercept('GET', '**/api/footer*', {
-      fixture: 'footerStrapiResponse.json',
-    }).as('getFooterStrapiData');
-
-    cy.intercept('GET', '**/api/our-work-sub-pages*', {
-      fixture: 'ourWorkSubPagesStrapiResponse.json',
-    }).as('getOurWorkSubPagesStrapiData');
-
     cy.intercept('GET', '**/api/our-donors-page*', {
       fixture: 'ourDonorsPageStrapiResponse.json',
     }).as('getOurDonorsPageStrapiData');

--- a/cypress/e2e/components/src/components/ourMissionVisionAndValuesPage.cy.js
+++ b/cypress/e2e/components/src/components/ourMissionVisionAndValuesPage.cy.js
@@ -8,6 +8,10 @@ describe('Our Mission Vision and Values Page', () => {
       fixture: 'footerStrapiResponse.json',
     }).as('getFooterStrapiData');
 
+    cy.intercept('GET', '**/api/our-work-sub-pages*', {
+      fixture: 'ourWorkSubPagesStrapiResponse.json',
+    }).as('getOurWorkSubPagesStrapiData');
+
     cy.intercept('GET', '**/api/mission-vision-and-values-page*', {
       fixture: 'ourMissionVisionAndValuesPageStrapiResponse.json',
     }).as('getOurMissionVisionAndValuesPageStrapiData');
@@ -16,6 +20,7 @@ describe('Our Mission Vision and Values Page', () => {
 
     cy.wait('@getNavigationBarStrapiData');
     cy.wait('@getFooterStrapiData');
+    cy.wait('@getOurWorkSubPagesStrapiData');
     cy.wait('@getOurMissionVisionAndValuesPageStrapiData');
   });
 

--- a/cypress/e2e/components/src/components/ourMissionVisionAndValuesPage.cy.js
+++ b/cypress/e2e/components/src/components/ourMissionVisionAndValuesPage.cy.js
@@ -1,17 +1,5 @@
 describe('Our Mission Vision and Values Page', () => {
   beforeEach(() => {
-    cy.intercept('GET', '**/api/navigation-bar*', {
-      fixture: 'navigationBarStrapiResponse.json',
-    }).as('getNavigationBarStrapiData');
-
-    cy.intercept('GET', '**/api/footer*', {
-      fixture: 'footerStrapiResponse.json',
-    }).as('getFooterStrapiData');
-
-    cy.intercept('GET', '**/api/our-work-sub-pages*', {
-      fixture: 'ourWorkSubPagesStrapiResponse.json',
-    }).as('getOurWorkSubPagesStrapiData');
-
     cy.intercept('GET', '**/api/mission-vision-and-values-page*', {
       fixture: 'ourMissionVisionAndValuesPageStrapiResponse.json',
     }).as('getOurMissionVisionAndValuesPageStrapiData');

--- a/cypress/e2e/components/src/components/ourTeamPage.cy.js
+++ b/cypress/e2e/components/src/components/ourTeamPage.cy.js
@@ -1,17 +1,5 @@
 describe('Our Team Page', () => {
   beforeEach(() => {
-    cy.intercept('GET', '**/api/navigation-bar*', {
-      fixture: 'navigationBarStrapiResponse.json',
-    }).as('getNavigationBarStrapiData');
-
-    cy.intercept('GET', '**/api/footer*', {
-      fixture: 'footerStrapiResponse.json',
-    }).as('getFooterStrapiData');
-
-    cy.intercept('GET', '**/api/our-work-sub-pages*', {
-      fixture: 'ourWorkSubPagesStrapiResponse.json',
-    }).as('getOurWorkSubPagesStrapiData');
-
     cy.intercept('GET', '**/api/our-team-page*', {
       fixture: 'ourTeamPageStrapiResponse.json',
     }).as('getOurTeamPageStrapiData');

--- a/cypress/e2e/components/src/components/ourTeamPage.cy.js
+++ b/cypress/e2e/components/src/components/ourTeamPage.cy.js
@@ -8,6 +8,10 @@ describe('Our Team Page', () => {
       fixture: 'footerStrapiResponse.json',
     }).as('getFooterStrapiData');
 
+    cy.intercept('GET', '**/api/our-work-sub-pages*', {
+      fixture: 'ourWorkSubPagesStrapiResponse.json',
+    }).as('getOurWorkSubPagesStrapiData');
+
     cy.intercept('GET', '**/api/our-team-page*', {
       fixture: 'ourTeamPageStrapiResponse.json',
     }).as('getOurTeamPageStrapiData');
@@ -16,6 +20,7 @@ describe('Our Team Page', () => {
 
     cy.wait('@getNavigationBarStrapiData');
     cy.wait('@getFooterStrapiData');
+    cy.wait('@getOurWorkSubPagesStrapiData');
     cy.wait('@getOurTeamPageStrapiData');
   });
 

--- a/cypress/e2e/components/src/components/ourWorkPage.cy.js
+++ b/cypress/e2e/components/src/components/ourWorkPage.cy.js
@@ -1,17 +1,5 @@
 describe('Our Work Page', () => {
   beforeEach(() => {
-    cy.intercept('GET', '**/api/navigation-bar*', {
-      fixture: 'navigationBarStrapiResponse.json',
-    }).as('getNavigationBarStrapiData');
-
-    cy.intercept('GET', '**/api/footer*', {
-      fixture: 'footerStrapiResponse.json',
-    }).as('getFooterStrapiData');
-
-    cy.intercept('GET', '**/api/our-work-sub-pages*', {
-      fixture: 'ourWorkSubPagesStrapiResponse.json',
-    }).as('getOurWorkSubPagesStrapiData');
-
     cy.intercept('GET', '**/api/our-work-page*', {
       fixture: 'ourWorkPageStrapiResponse.json',
     }).as('getOurWorkPageStrapiData');

--- a/cypress/e2e/components/src/components/ourWorkPage.cy.js
+++ b/cypress/e2e/components/src/components/ourWorkPage.cy.js
@@ -8,6 +8,10 @@ describe('Our Work Page', () => {
       fixture: 'footerStrapiResponse.json',
     }).as('getFooterStrapiData');
 
+    cy.intercept('GET', '**/api/our-work-sub-pages*', {
+      fixture: 'ourWorkSubPagesStrapiResponse.json',
+    }).as('getOurWorkSubPagesStrapiData');
+
     cy.intercept('GET', '**/api/our-work-page*', {
       fixture: 'ourWorkPageStrapiResponse.json',
     }).as('getOurWorkPageStrapiData');
@@ -16,6 +20,7 @@ describe('Our Work Page', () => {
 
     cy.wait('@getNavigationBarStrapiData');
     cy.wait('@getFooterStrapiData');
+    cy.wait('@getOurWorkSubPagesStrapiData');
     cy.wait('@getOurWorkPageStrapiData');
   });
 

--- a/cypress/e2e/components/src/components/ourWorkSubPage.cy.js
+++ b/cypress/e2e/components/src/components/ourWorkSubPage.cy.js
@@ -1,4 +1,4 @@
-describe('Stat Template Page', () => {
+describe('Our Work Sub Page', () => {
   beforeEach(() => {
     cy.intercept('GET', '**/api/navigation-bar*', {
       fixture: 'navigationBarStrapiResponse.json',
@@ -8,18 +8,18 @@ describe('Stat Template Page', () => {
       fixture: 'footerStrapiResponse.json',
     }).as('getFooterStrapiData');
 
-    cy.intercept('GET', '**/api/our-work-sub-pages/*', {
-      fixture: 'statTemplatePageStrapiResponse.json',
-    }).as('getOurWorkSubPageStrapiData');
+    cy.intercept('GET', '**/api/our-work-sub-pages*', {
+      fixture: 'ourWorkSubPagesStrapiResponse.json',
+    }).as('getOurWorkSubPagesStrapiData');
 
     cy.visit('/our-work/training-and-advocacy');
 
     cy.wait('@getNavigationBarStrapiData');
     cy.wait('@getFooterStrapiData');
-    cy.wait('@getOurWorkSubPageStrapiData');
+    cy.wait('@getOurWorkSubPagesStrapiData');
   });
 
-  it('should load a template stat page and verify all elements are present and functioning', () => {
+  it('should load a Our Work Sub page and verify all elements are present and functioning', () => {
     cy.get('[data-testid="navbar"]').should('be.visible');
 
     cy.get('[data-testid="landing-card-desktop"]').should('be.visible');
@@ -28,7 +28,7 @@ describe('Stat Template Page', () => {
     );
     cy.get('[data-testid="stat-template-page-metric"]').should(
       'have.length',
-      2
+      4
     );
     cy.get('[data-testid="stat-template-page-free-text"]').should('be.visible');
 

--- a/cypress/e2e/components/src/components/ourWorkSubPage.cy.js
+++ b/cypress/e2e/components/src/components/ourWorkSubPage.cy.js
@@ -1,17 +1,5 @@
 describe('Our Work Sub Page', () => {
   beforeEach(() => {
-    cy.intercept('GET', '**/api/navigation-bar*', {
-      fixture: 'navigationBarStrapiResponse.json',
-    }).as('getNavigationBarStrapiData');
-
-    cy.intercept('GET', '**/api/footer*', {
-      fixture: 'footerStrapiResponse.json',
-    }).as('getFooterStrapiData');
-
-    cy.intercept('GET', '**/api/our-work-sub-pages*', {
-      fixture: 'ourWorkSubPagesStrapiResponse.json',
-    }).as('getOurWorkSubPagesStrapiData');
-
     cy.visit('/our-work/training-and-advocacy');
 
     cy.wait('@getNavigationBarStrapiData');

--- a/cypress/e2e/components/src/components/ourWorkSubPage.cy.js
+++ b/cypress/e2e/components/src/components/ourWorkSubPage.cy.js
@@ -10,13 +10,13 @@ describe('Stat Template Page', () => {
 
     cy.intercept('GET', '**/api/our-work-sub-pages/*', {
       fixture: 'statTemplatePageStrapiResponse.json',
-    }).as('getTrainingAndAdvocacyPageStrapiData');
+    }).as('getOurWorkSubPageStrapiData');
 
-    cy.visit('/training-and-advocacy');
+    cy.visit('/our-work/training-and-advocacy');
 
     cy.wait('@getNavigationBarStrapiData');
     cy.wait('@getFooterStrapiData');
-    cy.wait('@getTrainingAndAdvocacyPageStrapiData');
+    cy.wait('@getOurWorkSubPageStrapiData');
   });
 
   it('should load a template stat page and verify all elements are present and functioning', () => {

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -18,3 +18,17 @@ import './commands';
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
+
+beforeEach(() => {
+  cy.intercept('GET', '**/api/navigation-bar*', {
+    fixture: 'navigationBarStrapiResponse.json',
+  }).as('getNavigationBarStrapiData');
+
+  cy.intercept('GET', '**/api/footer*', {
+    fixture: 'footerStrapiResponse.json',
+  }).as('getFooterStrapiData');
+
+  cy.intercept('GET', '**/api/our-work-sub-pages*', {
+    fixture: 'ourWorkSubPagesStrapiResponse.json',
+  }).as('getOurWorkSubPagesStrapiData');
+});

--- a/fixtures/ourWorkSubPagesStrapiResponse.json
+++ b/fixtures/ourWorkSubPagesStrapiResponse.json
@@ -1,0 +1,376 @@
+{
+  "data": [
+    {
+      "id": 1,
+      "attributes": {
+        "freeText": "Cras rutrum, felis et blandit scelerisque, dolor sem feugiat leo, a pellentesque sapien sapien ut ipsum. In a tortor sit amet libero lobortis vestibulum. Aliquam vitae gravida neque. Morbi a nunc dictum, vulputate eros vitae, accumsan dolor. Proin ac risus nunc. Ut iaculis ex orci, et semper elit fermentum sed. Susp endisse potenti. Phasellus semper ornare tellus eu egestas. Mauris semper tortor et ligula condimentum ullamcorper. Sed nec lectus non turpis porttitor accumsan quis sed lectus. Nam fermentum lobortis faucibus. Quisque consectetur felis vitae enim blandit, id porttitor augue ultrices.",
+        "url": "training-and-advocacy",
+        "landingImage": {
+          "id": 1,
+          "title": "Training & Advocacy",
+          "image": {
+            "data": {
+              "id": 48,
+              "attributes": {
+                "name": "get-involved-landing-image.svg",
+                "alternativeText": "get-involved-landing-image.svg",
+                "caption": "get-involved-landing-image.svg",
+                "width": 1344,
+                "height": 450,
+                "formats": null,
+                "hash": "get_involved_landing_image_ecb93f0f7e",
+                "ext": ".svg",
+                "mime": "image/svg+xml",
+                "size": 1030.17,
+                "url": "https://strapi-dr-s3-media-bucket.s3",
+                "previewUrl": null,
+                "provider": "aws-s3",
+                "provider_metadata": null,
+                "createdAt": "2025-01-19T19:09:15.280Z",
+                "updatedAt": "2025-01-19T19:09:15.280Z",
+                "isUrlSigned": true
+              }
+            }
+          }
+        },
+        "quote": {
+          "id": 1,
+          "author": "- Ban Ki-Moon, UN Secretary-General ",
+          "body": "‘Energy is the golden thread that connects economic growth, increased social equity, and an environment that allows the world to thrive.’"
+        },
+        "metrics": [
+          {
+            "id": 1,
+            "value": "16.6%",
+            "valueDescription": "Ghanian energy comes from renewable resources"
+          },
+          {
+            "id": 2,
+            "value": "1.02m",
+            "valueDescription": "Citizens of Ghana currently have energy insecurities"
+          },
+          {
+            "id": 3,
+            "value": "1.23k",
+            "valueDescription": "Homes that we have helped supply with solar panels"
+          },
+          {
+            "id": 4,
+            "value": "512",
+            "valueDescription": "renewable energy engineers we've trained"
+          }
+        ]
+      }
+    },
+    {
+      "id": 2,
+      "attributes": {
+        "freeText": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+        "url": "entrepreneurship",
+        "landingImage": {
+          "id": 2,
+          "title": "Entrepreneurship",
+          "image": {
+            "data": {
+              "id": 48,
+              "attributes": {
+                "name": "get-involved-landing-image.svg",
+                "alternativeText": "get-involved-landing-image.svg",
+                "caption": "get-involved-landing-image.svg",
+                "width": 1344,
+                "height": 450,
+                "formats": null,
+                "hash": "get_involved_landing_image_ecb93f0f7e",
+                "ext": ".svg",
+                "mime": "image/svg+xml",
+                "size": 1030.17,
+                "url": "https://strapi-dr-s3-media-bucket.s3",
+                "previewUrl": null,
+                "provider": "aws-s3",
+                "provider_metadata": null,
+                "createdAt": "2025-01-19T19:09:15.280Z",
+                "updatedAt": "2025-01-19T19:09:15.280Z",
+                "isUrlSigned": true
+              }
+            }
+          }
+        },
+        "quote": {
+          "id": 2,
+          "author": "- Ban Ki-Moon, UN Secretary-General ",
+          "body": "‘Energy is the golden thread that connects economic growth, increased social equity, and an environment that allows the world to thrive.’"
+        },
+        "metrics": [
+          {
+            "id": 5,
+            "value": "16.6%",
+            "valueDescription": "Ghanian energy comes from renewable resources"
+          },
+          {
+            "id": 6,
+            "value": "1.23k",
+            "valueDescription": "Homes that we have helped supply with solar panels"
+          },
+          {
+            "id": 7,
+            "value": "512",
+            "valueDescription": "renewable energy engineers we've trained"
+          },
+          {
+            "id": 8,
+            "value": "1.02m",
+            "valueDescription": "Citizens of Ghana currently have energy insecurities"
+          }
+        ]
+      }
+    },
+    {
+      "id": 3,
+      "attributes": {
+        "freeText": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+        "url": "solar-powered-schools",
+        "landingImage": {
+          "id": 3,
+          "title": "Solar Powered Schools",
+          "image": {
+            "data": {
+              "id": 48,
+              "attributes": {
+                "name": "get-involved-landing-image.svg",
+                "alternativeText": "get-involved-landing-image.svg",
+                "caption": "get-involved-landing-image.svg",
+                "width": 1344,
+                "height": 450,
+                "formats": null,
+                "hash": "get_involved_landing_image_ecb93f0f7e",
+                "ext": ".svg",
+                "mime": "image/svg+xml",
+                "size": 1030.17,
+                "url": "https://strapi-dr-s3-media-bucket.s3",
+                "previewUrl": null,
+                "provider": "aws-s3",
+                "provider_metadata": null,
+                "createdAt": "2025-01-19T19:09:15.280Z",
+                "updatedAt": "2025-01-19T19:09:15.280Z",
+                "isUrlSigned": true
+              }
+            }
+          }
+        },
+        "quote": {
+          "id": 3,
+          "author": "- Ban Ki-Moon, UN Secretary-General ",
+          "body": "‘Energy is the golden thread that connects economic growth, increased social equity, and an environment that allows the world to thrive.’"
+        },
+        "metrics": [
+          {
+            "id": 9,
+            "value": "16.6%",
+            "valueDescription": "Ghanian energy comes from renewable resources"
+          },
+          {
+            "id": 10,
+            "value": "1.23k",
+            "valueDescription": "Homes that we have helped supply with solar panels"
+          },
+          {
+            "id": 11,
+            "value": "512",
+            "valueDescription": "renewable energy engineers we've trained"
+          },
+          {
+            "id": 12,
+            "value": "1.02m",
+            "valueDescription": "Citizens of Ghana currently have energy insecurities"
+          }
+        ]
+      }
+    },
+    {
+      "id": 4,
+      "attributes": {
+        "freeText": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+        "url": "solar-powered-irrigation",
+        "landingImage": {
+          "id": 4,
+          "title": "Solar Powered Irrigation",
+          "image": {
+            "data": {
+              "id": 48,
+              "attributes": {
+                "name": "get-involved-landing-image.svg",
+                "alternativeText": "get-involved-landing-image.svg",
+                "caption": "get-involved-landing-image.svg",
+                "width": 1344,
+                "height": 450,
+                "formats": null,
+                "hash": "get_involved_landing_image_ecb93f0f7e",
+                "ext": ".svg",
+                "mime": "image/svg+xml",
+                "size": 1030.17,
+                "url": "https://strapi-dr-s3-media-bucket.s3",
+                "previewUrl": null,
+                "provider": "aws-s3",
+                "provider_metadata": null,
+                "createdAt": "2025-01-19T19:09:15.280Z",
+                "updatedAt": "2025-01-19T19:09:15.280Z",
+                "isUrlSigned": true
+              }
+            }
+          }
+        },
+        "quote": {
+          "id": 4,
+          "author": "- Ban Ki-Moon, UN Secretary-General ",
+          "body": "‘Energy is the golden thread that connects economic growth, increased social equity, and an environment that allows the world to thrive.’"
+        },
+        "metrics": [
+          {
+            "id": 13,
+            "value": "16.6%",
+            "valueDescription": "Ghanian energy comes from renewable resources"
+          },
+          {
+            "id": 14,
+            "value": "1.23k",
+            "valueDescription": "Homes that we have helped supply with solar panels"
+          },
+          {
+            "id": 15,
+            "value": "512",
+            "valueDescription": "renewable energy engineers we've trained"
+          },
+          {
+            "id": 16,
+            "value": "1.02m",
+            "valueDescription": "Citizens of Ghana currently have energy insecurities"
+          }
+        ]
+      }
+    },
+    {
+      "id": 5,
+      "attributes": {
+        "freeText": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+        "url": "solar-powered-clinics",
+        "landingImage": {
+          "id": 5,
+          "title": "Solar Powered Clinics",
+          "image": {
+            "data": {
+              "id": 48,
+              "attributes": {
+                "name": "get-involved-landing-image.svg",
+                "alternativeText": "get-involved-landing-image.svg",
+                "caption": "get-involved-landing-image.svg",
+                "width": 1344,
+                "height": 450,
+                "formats": null,
+                "hash": "get_involved_landing_image_ecb93f0f7e",
+                "ext": ".svg",
+                "mime": "image/svg+xml",
+                "size": 1030.17,
+                "url": "https://strapi-dr-s3-media-bucket.s3",
+                "previewUrl": null,
+                "provider": "aws-s3",
+                "provider_metadata": null,
+                "createdAt": "2025-01-19T19:09:15.280Z",
+                "updatedAt": "2025-01-19T19:09:15.280Z",
+                "isUrlSigned": true
+              }
+            }
+          }
+        },
+        "quote": {
+          "id": 5,
+          "author": "- Ban Ki-Moon, UN Secretary-General ",
+          "body": "‘Energy is the golden thread that connects economic growth, increased social equity, and an environment that allows the world to thrive.’"
+        },
+        "metrics": [
+          {
+            "id": 17,
+            "value": "16.6%",
+            "valueDescription": "Ghanian energy comes from renewable resources"
+          },
+          {
+            "id": 18,
+            "value": "1.23k",
+            "valueDescription": "Homes that we have helped supply with solar panels"
+          },
+          {
+            "id": 19,
+            "value": "512",
+            "valueDescription": "renewable energy engineers we've trained"
+          },
+          {
+            "id": 20,
+            "value": "1.02m",
+            "valueDescription": "Citizens of Ghana currently have energy insecurities"
+          }
+        ]
+      }
+    },
+    {
+      "id": 6,
+      "attributes": {
+        "freeText": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+        "url": "cleaner-cooking",
+        "landingImage": {
+          "id": 6,
+          "title": "Cleaner Cooking",
+          "image": {
+            "data": {
+              "id": 48,
+              "attributes": {
+                "name": "get-involved-landing-image.svg",
+                "alternativeText": "get-involved-landing-image.svg",
+                "caption": "get-involved-landing-image.svg",
+                "width": 1344,
+                "height": 450,
+                "formats": null,
+                "hash": "get_involved_landing_image_ecb93f0f7e",
+                "ext": ".svg",
+                "mime": "image/svg+xml",
+                "size": 1030.17,
+                "url": "https://strapi-dr-s3-media-bucket.s3",
+                "previewUrl": null,
+                "provider": "aws-s3",
+                "provider_metadata": null,
+                "createdAt": "2025-01-19T19:09:15.280Z",
+                "updatedAt": "2025-01-19T19:09:15.280Z",
+                "isUrlSigned": true
+              }
+            }
+          }
+        },
+        "quote": {
+          "id": 6,
+          "author": "- Ban Ki-Moon, UN Secretary-General ",
+          "body": "‘Energy is the golden thread that connects economic growth, increased social equity, and an environment that allows the world to thrive.’"
+        },
+        "metrics": [
+          {
+            "id": 21,
+            "value": "16.6%",
+            "valueDescription": "Ghanian energy comes from renewable resources"
+          },
+          {
+            "id": 22,
+            "value": "1.23k",
+            "valueDescription": "Homes that we have helped supply with solar panels"
+          },
+          {
+            "id": 23,
+            "value": "512",
+            "valueDescription": "renewable energy engineers we've trained"
+          },
+          {
+            "id": 24,
+            "value": "1.02m",
+            "valueDescription": "Citizens of Ghana currently have energy insecurities"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/fixtures/statTemplatePageStrapiResponse.json
+++ b/fixtures/statTemplatePageStrapiResponse.json
@@ -2,6 +2,7 @@
   "data": {
     "id": 1,
     "attributes": {
+      "url": "test-url",
       "freeText": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
       "landingImage": {
         "id": 2,

--- a/src/api/strapiApi.test.ts
+++ b/src/api/strapiApi.test.ts
@@ -11,6 +11,7 @@ import {
   getOurMissionVisionAndValuesPageStrapiData,
   getOurTeamPageStrapiData,
   getOurWorkPageStrapiData,
+  getOurWorkSubPageStrapiData,
 } from './strapiApi';
 import LandingPageFactory from '../test/factories/strapi/LandingPageFactory';
 import NavigationBarFactory from '../test/factories/strapi/NavigationBarFactory';
@@ -22,6 +23,8 @@ import AboutUsPageFactory from '../test/factories/strapi/AboutUsPageFactory';
 import OurWorkPageFactory from '../test/factories/strapi/OurWorkPageFactory';
 import GetInvolvedPageFactory from '../test/factories/strapi/GetInvolvedPageFactory';
 import DonatePageFactory from '../test/factories/strapi/DonatePageFactory';
+import StatTemplatePageFactory from '../test/factories/strapi/StatTemplatePageFactory';
+import { OurWorkSubPages } from '../data/enums/OurWorkSubPages';
 
 interface MockData<T> {
   data: {
@@ -260,5 +263,29 @@ describe('strapiApi', () => {
     //     'Request failed with status code 500'
     //   );
     // });
+  });
+
+  describe('getOurWorkSubPageStrapiData', () => {
+    test('should get a our work sub page data successfully', async () => {
+      const statTemplatePageFactory = new StatTemplatePageFactory();
+      const mockResponse = statTemplatePageFactory.getMockResponse();
+      const apiUrl = statTemplatePageFactory.getApiUrl();
+      await setup(apiUrl, mockResponse, 200);
+
+      const response = await getOurWorkSubPageStrapiData(
+        OurWorkSubPages.TrainingAndAdvocacy
+      );
+      expect(response).toEqual(mockResponse.data.attributes);
+    });
+
+    test('should handle errors when get a our work sub page data returns a 500', async () => {
+      const statTemplatePageFactory = new StatTemplatePageFactory();
+      const emptyMockData = statTemplatePageFactory.getEmptyMockData();
+      const apiUrl = statTemplatePageFactory.getApiUrl();
+      await setup(apiUrl, emptyMockData, 500);
+      await expect(
+        getOurWorkSubPageStrapiData(OurWorkSubPages.TrainingAndAdvocacy)
+      ).rejects.toThrow('Request failed with status code 500');
+    });
   });
 });

--- a/src/api/strapiApi.test.ts
+++ b/src/api/strapiApi.test.ts
@@ -11,7 +11,7 @@ import {
   getOurMissionVisionAndValuesPageStrapiData,
   getOurTeamPageStrapiData,
   getOurWorkPageStrapiData,
-  getOurWorkSubPageStrapiData,
+  getOurWorkSubPagesStrapiData,
 } from './strapiApi';
 import LandingPageFactory from '../test/factories/strapi/LandingPageFactory';
 import NavigationBarFactory from '../test/factories/strapi/NavigationBarFactory';
@@ -23,19 +23,14 @@ import AboutUsPageFactory from '../test/factories/strapi/AboutUsPageFactory';
 import OurWorkPageFactory from '../test/factories/strapi/OurWorkPageFactory';
 import GetInvolvedPageFactory from '../test/factories/strapi/GetInvolvedPageFactory';
 import DonatePageFactory from '../test/factories/strapi/DonatePageFactory';
-import StatTemplatePageFactory from '../test/factories/strapi/StatTemplatePageFactory';
-import { OurWorkSubPages } from '../data/enums/OurWorkSubPages';
-
-interface MockData<T> {
-  data: {
-    attributes: T;
-  };
-}
+import OurWorkSubPagesFactory from '../test/factories/strapi/OurWorkSubPagesFactory';
+import { StrapiResponseCollection } from '../data/interfaces/util/StrapiResponseCollection';
+import { StrapiResponse } from '../data/interfaces/util/StrapiResponse';
 
 describe('strapiApi', () => {
   const setup = async <T>(
     apiUrl: string,
-    mockData: MockData<T>,
+    mockData: StrapiResponse<T> | StrapiResponseCollection<T>,
     statusCode: number
   ) => {
     AXIOS_MOCK.onGet(apiUrl).replyOnce(statusCode, mockData);
@@ -265,27 +260,25 @@ describe('strapiApi', () => {
     // });
   });
 
-  describe('getOurWorkSubPageStrapiData', () => {
-    test('should get a our work sub page data successfully', async () => {
-      const statTemplatePageFactory = new StatTemplatePageFactory();
-      const mockResponse = statTemplatePageFactory.getMockResponse();
-      const apiUrl = statTemplatePageFactory.getApiUrl();
+  describe('getOurWorkSubPagesStrapiData', () => {
+    test('should get all data for our work sub pages successfully', async () => {
+      const ourWorkSubPagesFactory = new OurWorkSubPagesFactory();
+      const mockResponse = ourWorkSubPagesFactory.getMockResponse();
+      const apiUrl = ourWorkSubPagesFactory.getApiUrl();
       await setup(apiUrl, mockResponse, 200);
 
-      const response = await getOurWorkSubPageStrapiData(
-        OurWorkSubPages.TrainingAndAdvocacy
-      );
-      expect(response).toEqual(mockResponse.data.attributes);
+      const response = await getOurWorkSubPagesStrapiData();
+      expect(response).toEqual(mockResponse);
     });
 
     test('should handle errors when get a our work sub page data returns a 500', async () => {
-      const statTemplatePageFactory = new StatTemplatePageFactory();
-      const emptyMockData = statTemplatePageFactory.getEmptyMockData();
-      const apiUrl = statTemplatePageFactory.getApiUrl();
+      const ourWorkSubPagesFactory = new OurWorkSubPagesFactory();
+      const emptyMockData = ourWorkSubPagesFactory.getEmptyMockData();
+      const apiUrl = ourWorkSubPagesFactory.getApiUrl();
       await setup(apiUrl, emptyMockData, 500);
-      await expect(
-        getOurWorkSubPageStrapiData(OurWorkSubPages.TrainingAndAdvocacy)
-      ).rejects.toThrow('Request failed with status code 500');
+      await expect(getOurWorkSubPagesStrapiData()).rejects.toThrow(
+        'Request failed with status code 500'
+      );
     });
   });
 });

--- a/src/api/strapiApi.tsx
+++ b/src/api/strapiApi.tsx
@@ -10,8 +10,6 @@ import { AboutUsPageStrapiContent } from '../data/interfaces/about-us-page/About
 import { OurWorkPageStrapiContent } from '../data/interfaces/our-work-page/OurWorkPageStrapiContent';
 import { GetInvolvedPageStrapiContent } from '../data/interfaces/get-involved-page/GetInvolvedPageStrapiContent';
 import { DonatePageStrapiContent } from '../data/interfaces/donate-page/DonatePageStrapiContent';
-import { StatTemplatePageStrapiContent } from '../data/interfaces/stat-template-page/StatTemplatePageStrapiContent';
-import { OurWorkSubPages } from '../data/enums/OurWorkSubPages';
 import { StatTemplatePagesStrapiContent } from '../data/interfaces/stat-template-page/StatTemplatePagesStrapiContent';
 
 export async function getNavigationBarStrapiData(): Promise<NavigationBarStrapiContent> {
@@ -125,17 +123,6 @@ export async function getDonatePageStrapiData(): Promise<DonatePageStrapiContent
     'paymentSection.paymentOptionIcon',
   ]);
   return fetchStrapiData('donate-page', query);
-}
-
-export async function getOurWorkSubPageStrapiData(
-  pageId: OurWorkSubPages
-): Promise<StatTemplatePageStrapiContent> {
-  const query = buildStrapiEndpointQuery([
-    'landingImage.image',
-    'quote',
-    'metrics',
-  ]);
-  return fetchStrapiData(`our-work-sub-pages/${pageId}`, query);
 }
 
 export async function getOurWorkSubPagesStrapiData(): Promise<StatTemplatePagesStrapiContent> {

--- a/src/api/strapiApi.tsx
+++ b/src/api/strapiApi.tsx
@@ -126,14 +126,13 @@ export async function getDonatePageStrapiData(): Promise<DonatePageStrapiContent
   return fetchStrapiData('donate-page', query);
 }
 
-export async function getTrainingAndAdvocacyPageStrapiData(): Promise<StatTemplatePageStrapiContent> {
+export async function getOurWorkSubPageStrapiData(
+  pageId: OurWorkSubPages
+): Promise<StatTemplatePageStrapiContent> {
   const query = buildStrapiEndpointQuery([
     'landingImage.image',
     'quote',
     'metrics',
   ]);
-  return fetchStrapiData(
-    `our-work-sub-pages/${OurWorkSubPages.TrainingAndAdvocacy}`,
-    query
-  );
+  return fetchStrapiData(`our-work-sub-pages/${pageId}`, query);
 }

--- a/src/api/strapiApi.tsx
+++ b/src/api/strapiApi.tsx
@@ -4,7 +4,7 @@ import { LandingPageStrapiContent } from '../data/interfaces/landing-page/Landin
 import { OurMissionVisionAndValuesPageStrapiContent } from '../data/interfaces/our-mission-vision-and-values-page/OurMissionVisionAndValuesPageStrapiContent';
 import { OurTeamPageStrapiContent } from '../data/interfaces/our-team-page/OurTeamPageStrapiContent';
 import { buildStrapiEndpointQuery } from './util/buildStrapiEndpointQuery';
-import { fetchStrapiData } from './util/fetchStrapiData';
+import { fetchAllStrapiData, fetchStrapiData } from './util/fetchStrapiData';
 import { OurDonorsPageStrapiContent } from '../data/interfaces/our-donor-page/OurDonorsPageStrapiContent';
 import { AboutUsPageStrapiContent } from '../data/interfaces/about-us-page/AboutUsPageStrapiContent';
 import { OurWorkPageStrapiContent } from '../data/interfaces/our-work-page/OurWorkPageStrapiContent';
@@ -12,6 +12,7 @@ import { GetInvolvedPageStrapiContent } from '../data/interfaces/get-involved-pa
 import { DonatePageStrapiContent } from '../data/interfaces/donate-page/DonatePageStrapiContent';
 import { StatTemplatePageStrapiContent } from '../data/interfaces/stat-template-page/StatTemplatePageStrapiContent';
 import { OurWorkSubPages } from '../data/enums/OurWorkSubPages';
+import { StatTemplatePagesStrapiContent } from '../data/interfaces/stat-template-page/StatTemplatePagesStrapiContent';
 
 export async function getNavigationBarStrapiData(): Promise<NavigationBarStrapiContent> {
   const query = buildStrapiEndpointQuery([
@@ -135,4 +136,13 @@ export async function getOurWorkSubPageStrapiData(
     'metrics',
   ]);
   return fetchStrapiData(`our-work-sub-pages/${pageId}`, query);
+}
+
+export async function getOurWorkSubPagesStrapiData(): Promise<StatTemplatePagesStrapiContent> {
+  const query = buildStrapiEndpointQuery([
+    'landingImage.image',
+    'quote',
+    'metrics',
+  ]);
+  return fetchAllStrapiData(`our-work-sub-pages`, query);
 }

--- a/src/api/strapiApi.tsx
+++ b/src/api/strapiApi.tsx
@@ -4,13 +4,13 @@ import { LandingPageStrapiContent } from '../data/interfaces/landing-page/Landin
 import { OurMissionVisionAndValuesPageStrapiContent } from '../data/interfaces/our-mission-vision-and-values-page/OurMissionVisionAndValuesPageStrapiContent';
 import { OurTeamPageStrapiContent } from '../data/interfaces/our-team-page/OurTeamPageStrapiContent';
 import { buildStrapiEndpointQuery } from './util/buildStrapiEndpointQuery';
-import { fetchAllStrapiData, fetchStrapiData } from './util/fetchStrapiData';
 import { OurDonorsPageStrapiContent } from '../data/interfaces/our-donor-page/OurDonorsPageStrapiContent';
 import { AboutUsPageStrapiContent } from '../data/interfaces/about-us-page/AboutUsPageStrapiContent';
 import { OurWorkPageStrapiContent } from '../data/interfaces/our-work-page/OurWorkPageStrapiContent';
 import { GetInvolvedPageStrapiContent } from '../data/interfaces/get-involved-page/GetInvolvedPageStrapiContent';
 import { DonatePageStrapiContent } from '../data/interfaces/donate-page/DonatePageStrapiContent';
 import { StatTemplatePagesStrapiContent } from '../data/interfaces/stat-template-page/StatTemplatePagesStrapiContent';
+import { fetchStrapiData } from './util/fetchStrapiData';
 
 export async function getNavigationBarStrapiData(): Promise<NavigationBarStrapiContent> {
   const query = buildStrapiEndpointQuery([
@@ -131,5 +131,5 @@ export async function getOurWorkSubPagesStrapiData(): Promise<StatTemplatePagesS
     'quote',
     'metrics',
   ]);
-  return fetchAllStrapiData(`our-work-sub-pages`, query);
+  return fetchStrapiData(`our-work-sub-pages`, query, true);
 }

--- a/src/api/util/fetchStrapiData.ts
+++ b/src/api/util/fetchStrapiData.ts
@@ -18,3 +18,16 @@ export async function fetchStrapiData(endpoint: string, query = {}) {
     throw error;
   }
 }
+
+export async function fetchAllStrapiData(endpoint: string, query = {}) {
+  try {
+    const response = await axios.get(
+      `${import.meta.env.VITE_BASE_URL}/api/${endpoint}?${query}`,
+      strapiConfig
+    );
+    return response.data;
+  } catch (error) {
+    console.error('Error fetching Strapi data:', error);
+    throw error;
+  }
+}

--- a/src/api/util/fetchStrapiData.ts
+++ b/src/api/util/fetchStrapiData.ts
@@ -6,26 +6,17 @@ const strapiConfig = {
   },
 };
 
-export async function fetchStrapiData(endpoint: string, query = {}) {
+export async function fetchStrapiData(
+  endpoint: string,
+  query = {},
+  returnCollection = false
+) {
   try {
     const response = await axios.get(
       `${import.meta.env.VITE_BASE_URL}/api/${endpoint}?${query}`,
       strapiConfig
     );
-    return response.data.data.attributes;
-  } catch (error) {
-    console.error('Error fetching Strapi data:', error);
-    throw error;
-  }
-}
-
-export async function fetchAllStrapiData(endpoint: string, query = {}) {
-  try {
-    const response = await axios.get(
-      `${import.meta.env.VITE_BASE_URL}/api/${endpoint}?${query}`,
-      strapiConfig
-    );
-    return response.data;
+    return returnCollection ? response.data : response.data.data.attributes;
   } catch (error) {
     console.error('Error fetching Strapi data:', error);
     throw error;

--- a/src/components/stat-template-page/stat-template-page-quote-section/statTemplatePageQuoteSection.tsx
+++ b/src/components/stat-template-page/stat-template-page-quote-section/statTemplatePageQuoteSection.tsx
@@ -12,7 +12,7 @@ const StatTemplatePageQuoteSection: React.FC<Props> = ({ quoteData }) => {
       data-testid="stat-template-page-quote-section"
       className="stat-template-page-quote-section-wrapper mb-5"
     >
-      <div className="p-4 stat-template-page-quote-section-body">
+      <div className="p-4 stat-template-page-quote-section-body text-center text-sm-center">
         <p
           data-testid="stat-template-page-quote-body"
           className="fs-2 fw-bolder"

--- a/src/data/enums/OurWorkSubPages.ts
+++ b/src/data/enums/OurWorkSubPages.ts
@@ -1,4 +1,8 @@
 export enum OurWorkSubPages {
   TrainingAndAdvocacy = '1',
   Entrepreneurship = '2',
+  SolarPoweredSchools = '3',
+  SolarPoweredIrrigation = '4',
+  SolarPoweredClinics = '5',
+  CleanerCooking = '6',
 }

--- a/src/data/enums/OurWorkSubPages.ts
+++ b/src/data/enums/OurWorkSubPages.ts
@@ -1,3 +1,4 @@
 export enum OurWorkSubPages {
   TrainingAndAdvocacy = '1',
+  Entrepreneurship = '2',
 }

--- a/src/data/enums/OurWorkSubPages.ts
+++ b/src/data/enums/OurWorkSubPages.ts
@@ -1,8 +1,0 @@
-export enum OurWorkSubPages {
-  TrainingAndAdvocacy = '1',
-  Entrepreneurship = '2',
-  SolarPoweredSchools = '3',
-  SolarPoweredIrrigation = '4',
-  SolarPoweredClinics = '5',
-  CleanerCooking = '6',
-}

--- a/src/data/interfaces/stat-template-page/StatTemplatePageStrapiContent.ts
+++ b/src/data/interfaces/stat-template-page/StatTemplatePageStrapiContent.ts
@@ -1,6 +1,7 @@
 import { LandingCard } from '../landing-card/LandingCard';
 
 export interface StatTemplatePageStrapiContent {
+  url: string;
   landingImage: LandingCard;
   quote: Quote;
   metrics: Array<Metric>;

--- a/src/data/interfaces/stat-template-page/StatTemplatePagesStrapiContent.ts
+++ b/src/data/interfaces/stat-template-page/StatTemplatePagesStrapiContent.ts
@@ -1,9 +1,7 @@
 import { StatTemplatePageStrapiContent } from './StatTemplatePageStrapiContent';
 
 export interface StatTemplatePagesStrapiContent {
-  data: Array<NestedStatTemplatePageStrapiContent>;
-}
-
-export interface NestedStatTemplatePageStrapiContent {
-  attributes: StatTemplatePageStrapiContent;
+  data: Array<{
+    attributes: StatTemplatePageStrapiContent;
+  }>;
 }

--- a/src/data/interfaces/stat-template-page/StatTemplatePagesStrapiContent.ts
+++ b/src/data/interfaces/stat-template-page/StatTemplatePagesStrapiContent.ts
@@ -1,0 +1,9 @@
+import { StatTemplatePageStrapiContent } from './StatTemplatePageStrapiContent';
+
+export interface StatTemplatePagesStrapiContent {
+  data: Array<NestedStatTemplatePageStrapiContent>;
+}
+
+export interface NestedStatTemplatePageStrapiContent {
+  attributes: StatTemplatePageStrapiContent;
+}

--- a/src/data/interfaces/util/StrapiResponseCollection.ts
+++ b/src/data/interfaces/util/StrapiResponseCollection.ts
@@ -1,0 +1,5 @@
+export interface StrapiResponseCollection<T> {
+  data: Array<{
+    attributes: T;
+  }>;
+}

--- a/src/data/types/LoaderData.ts
+++ b/src/data/types/LoaderData.ts
@@ -5,7 +5,6 @@ import { OurDonorsPageStrapiContent } from '../interfaces/our-donor-page/OurDono
 import { OurMissionVisionAndValuesPageStrapiContent } from '../interfaces/our-mission-vision-and-values-page/OurMissionVisionAndValuesPageStrapiContent';
 import { OurTeamPageStrapiContent } from '../interfaces/our-team-page/OurTeamPageStrapiContent';
 import { OurWorkPageStrapiContent } from '../interfaces/our-work-page/OurWorkPageStrapiContent';
-import { StatTemplatePageStrapiContent } from '../interfaces/stat-template-page/StatTemplatePageStrapiContent';
 
 export type LoaderData = {
   landingPageStrapiData: LandingPageStrapiContent;
@@ -15,5 +14,4 @@ export type LoaderData = {
   aboutUsPageStrapiData: AboutUsPageStrapiContent;
   ourWorkPageStrapiData: OurWorkPageStrapiContent;
   getInvolvedPageStrapiData: GetInvolvedPageStrapiContent;
-  statTemplatePageStrapiData: StatTemplatePageStrapiContent;
 };

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,13 +4,15 @@ import { createRoot } from 'react-dom/client';
 import { RouterProvider } from 'react-router-dom';
 import Loading from './components/loading/Loading';
 import './index.scss';
-import router from './routes';
 import { SharedDataProvider } from './contexts/SharedDataProvider';
+import createRoutes from './routes';
 
-createRoot(document.getElementById('root')!).render(
-  <StrictMode>
-    <SharedDataProvider>
-      <RouterProvider router={router} fallbackElement={<Loading />} />
-    </SharedDataProvider>
-  </StrictMode>
-);
+createRoutes().then((router) => {
+  createRoot(document.getElementById('root')!).render(
+    <StrictMode>
+      <SharedDataProvider>
+        <RouterProvider router={router} fallbackElement={<Loading />} />
+      </SharedDataProvider>
+    </StrictMode>
+  );
+});

--- a/src/pages/stat-template-page/StatTemplatePage.tsx
+++ b/src/pages/stat-template-page/StatTemplatePage.tsx
@@ -8,30 +8,30 @@ import StatTemplatePageMetric from '../../components/stat-template-page/stat-tem
 import { StatTemplatePageStrapiContent } from '../../data/interfaces/stat-template-page/StatTemplatePageStrapiContent';
 
 type Props = {
-  data: StatTemplatePageStrapiContent;
+  strapiData: StatTemplatePageStrapiContent;
 };
 
-const StatTemplatePage: React.FC<Props> = ({ data }) => {
+const StatTemplatePage: React.FC<Props> = ({ strapiData }) => {
   return (
     <PageWrapper>
       <Row>
         <Col>
           <div className="d-none d-sm-block mb-5">
-            <LandingCardDesktop landingCard={data.landingImage} />
+            <LandingCardDesktop landingCard={strapiData.landingImage} />
           </div>
           <div className="d-sm-none">
-            <LandingCardMobile landingCard={data.landingImage} />
+            <LandingCardMobile landingCard={strapiData.landingImage} />
           </div>
         </Col>
       </Row>
       <Container className="mb-5">
         <Row className="gx-5 mb-5">
           <Col xl="4">
-            <StatTemplatePageQuoteSection quoteData={data.quote} />
+            <StatTemplatePageQuoteSection quoteData={strapiData.quote} />
           </Col>
           <Col xl={{ span: 7, offset: 1 }} sm="12">
             <Row>
-              {data.metrics.map((metric, index) => (
+              {strapiData.metrics.map((metric, index) => (
                 <Col key={index} xl="6" sm="12">
                   <StatTemplatePageMetric metricData={metric} />
                 </Col>
@@ -46,7 +46,7 @@ const StatTemplatePage: React.FC<Props> = ({ data }) => {
             data-testid="stat-template-page-free-text"
             className="fs-4 px-5 text-center"
           >
-            {data.freeText}
+            {strapiData.freeText}
           </p>
         </Col>
       </Row>

--- a/src/pages/stat-template-page/StatTemplatePage.tsx
+++ b/src/pages/stat-template-page/StatTemplatePage.tsx
@@ -1,41 +1,37 @@
 import React from 'react';
 import PageWrapper from '../../components/page-wrapper/PageWrapper';
 import { Col, Container, Row } from 'react-bootstrap';
-import { useLoaderData } from 'react-router-dom';
-import { LoaderData } from '../../data/types/LoaderData';
 import LandingCardDesktop from '../../components/landing-card/desktop/LandingCardDesktop';
 import LandingCardMobile from '../../components/landing-card/mobile/landingCardMobile';
 import StatTemplatePageQuoteSection from '../../components/stat-template-page/stat-template-page-quote-section/statTemplatePageQuoteSection';
 import StatTemplatePageMetric from '../../components/stat-template-page/stat-template-page-metric/statTemplatePageMetric';
+import { StatTemplatePageStrapiContent } from '../../data/interfaces/stat-template-page/StatTemplatePageStrapiContent';
 
-const StatTemplatePage: React.FC = () => {
-  const { statTemplatePageStrapiData } = useLoaderData() as LoaderData;
+type Props = {
+  data: StatTemplatePageStrapiContent;
+};
+
+const StatTemplatePage: React.FC<Props> = ({ data }) => {
   return (
     <PageWrapper>
       <Row>
         <Col>
           <div className="d-none d-sm-block mb-5">
-            <LandingCardDesktop
-              landingCard={statTemplatePageStrapiData.landingImage}
-            />
+            <LandingCardDesktop landingCard={data.landingImage} />
           </div>
           <div className="d-sm-none">
-            <LandingCardMobile
-              landingCard={statTemplatePageStrapiData.landingImage}
-            />
+            <LandingCardMobile landingCard={data.landingImage} />
           </div>
         </Col>
       </Row>
       <Container className="mb-5">
         <Row className="gx-5 mb-5">
           <Col xl="4">
-            <StatTemplatePageQuoteSection
-              quoteData={statTemplatePageStrapiData.quote}
-            />
+            <StatTemplatePageQuoteSection quoteData={data.quote} />
           </Col>
           <Col xl={{ span: 7, offset: 1 }} sm="12">
             <Row>
-              {statTemplatePageStrapiData.metrics.map((metric, index) => (
+              {data.metrics.map((metric, index) => (
                 <Col key={index} xl="6" sm="12">
                   <StatTemplatePageMetric metricData={metric} />
                 </Col>
@@ -50,7 +46,7 @@ const StatTemplatePage: React.FC = () => {
             data-testid="stat-template-page-free-text"
             className="fs-4 px-5 text-center"
           >
-            {statTemplatePageStrapiData.freeText}
+            {data.freeText}
           </p>
         </Col>
       </Row>

--- a/src/pages/stat-template-page/statTemplatePage.test.tsx
+++ b/src/pages/stat-template-page/statTemplatePage.test.tsx
@@ -1,15 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
-import { MemoryRouter, useLoaderData } from 'react-router-dom';
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  Mock,
-  test,
-  vi,
-} from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import navigationBarFactory from '../../test/factories/strapi/NavigationBarFactory';
 import FooterFactory from '../../test/factories/strapi/FooterFactory';
 import { SharedDataContext } from '../../contexts/SharedDataProvider';
@@ -25,15 +17,13 @@ vi.mock('react-router-dom', async () => {
 });
 
 describe('StatTemplatePage', () => {
-  const mockLoaderData = {
-    statTemplatePageStrapiData: new StatTemplatePageFactory().getMockData(),
-  };
+  const mockStatTemplatePageStrapiData =
+    new StatTemplatePageFactory().getMockData();
 
   const navigationBarStrapiData = new navigationBarFactory().getMockData();
   const footerStrapiData = new FooterFactory().getMockData();
 
   const setup = async () => {
-    (useLoaderData as Mock).mockReturnValue(mockLoaderData);
     render(
       <SharedDataContext.Provider
         value={{
@@ -42,7 +32,7 @@ describe('StatTemplatePage', () => {
         }}
       >
         <MemoryRouter>
-          <StatTemplatePage />
+          <StatTemplatePage data={mockStatTemplatePageStrapiData} />
         </MemoryRouter>
       </SharedDataContext.Provider>
     );

--- a/src/pages/stat-template-page/statTemplatePage.test.tsx
+++ b/src/pages/stat-template-page/statTemplatePage.test.tsx
@@ -32,7 +32,7 @@ describe('StatTemplatePage', () => {
         }}
       >
         <MemoryRouter>
-          <StatTemplatePage data={mockStatTemplatePageStrapiData} />
+          <StatTemplatePage strapiData={mockStatTemplatePageStrapiData} />
         </MemoryRouter>
       </SharedDataContext.Provider>
     );

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -128,6 +128,54 @@ const router = createBrowserRouter([
       };
     },
   },
+  {
+    path: '/our-work/solar-powered-schools',
+    element: <StatTemplatePage />,
+    loader: async () => {
+      const statTemplatePageStrapiData = await getOurWorkSubPageStrapiData(
+        OurWorkSubPages.SolarPoweredSchools
+      );
+      return {
+        statTemplatePageStrapiData,
+      };
+    },
+  },
+  {
+    path: '/our-work/solar-powered-irrigation',
+    element: <StatTemplatePage />,
+    loader: async () => {
+      const statTemplatePageStrapiData = await getOurWorkSubPageStrapiData(
+        OurWorkSubPages.SolarPoweredIrrigation
+      );
+      return {
+        statTemplatePageStrapiData,
+      };
+    },
+  },
+  {
+    path: '/our-work/solar-powered-clinics',
+    element: <StatTemplatePage />,
+    loader: async () => {
+      const statTemplatePageStrapiData = await getOurWorkSubPageStrapiData(
+        OurWorkSubPages.SolarPoweredClinics
+      );
+      return {
+        statTemplatePageStrapiData,
+      };
+    },
+  },
+  {
+    path: '/our-work/cleaner-cooking',
+    element: <StatTemplatePage />,
+    loader: async () => {
+      const statTemplatePageStrapiData = await getOurWorkSubPageStrapiData(
+        OurWorkSubPages.CleanerCooking
+      );
+      return {
+        statTemplatePageStrapiData,
+      };
+    },
+  },
 ]);
 
 export default router;

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -9,7 +9,7 @@ import {
   getOurMissionVisionAndValuesPageStrapiData,
   getOurTeamPageStrapiData,
   getOurWorkPageStrapiData,
-  getOurWorkSubPageStrapiData,
+  getOurWorkSubPagesStrapiData,
 } from './api/strapiApi';
 import LandingPage from './pages/landing-page/LandingPage';
 import OurMissionVisionAndValuesPage from './pages/our-mission-vision-and-values-page/OurMissionVisionAndValuesPage';
@@ -20,162 +20,104 @@ import OurWorkPage from './pages/our-work-page/OurWorkPage';
 import GetInvolvedPage from './pages/get-involved-page/GetInvolvedPage';
 import DonatePage from './pages/donate-page/DonatePage';
 import StatTemplatePage from './pages/stat-template-page/StatTemplatePage';
-import { OurWorkSubPages } from './data/enums/OurWorkSubPages';
+import { StatTemplatePagesStrapiContent } from './data/interfaces/stat-template-page/StatTemplatePagesStrapiContent';
 
-const router = createBrowserRouter([
-  {
-    path: '/',
-    element: <LandingPage />,
-    loader: async () => {
-      const landingPageStrapiData = await getLandingPageStrapiData();
-      return {
-        landingPageStrapiData,
-      };
-    },
-  },
-  {
-    path: '/our-mission-vision-and-values',
-    element: <OurMissionVisionAndValuesPage />,
-    loader: async () => {
-      const ourMissionVisionAndValuesStrapiData =
-        await getOurMissionVisionAndValuesPageStrapiData();
-      return {
-        ourMissionVisionAndValuesStrapiData,
-      };
-    },
-  },
-  {
-    path: '/our-team',
-    element: <OurTeamPage />,
-    loader: async () => {
-      const ourTeamPageStrapiData = await getOurTeamPageStrapiData();
-      return {
-        ourTeamPageStrapiData,
-      };
-    },
-  },
-  {
-    path: '/our-donors',
-    element: <OurDonorsPage />,
-    loader: async () => {
-      const ourDonorsPageStrapiData = await getOurDonorsPageStrapiData();
-      return {
-        ourDonorsPageStrapiData,
-      };
-    },
-  },
-  {
-    path: '/about-us',
-    element: <AboutUsPage />,
-    loader: async () => {
-      const aboutUsPageStrapiData = await getAboutUsPageStrapiData();
-      return {
-        aboutUsPageStrapiData,
-      };
-    },
-  },
-  {
-    path: '/get-involved',
-    element: <GetInvolvedPage />,
-    loader: async () => {
-      const getInvolvedPageStrapiData = await getGetInvolvedPageStrapiData();
-      return {
-        getInvolvedPageStrapiData,
-      };
-    },
-  },
-  {
-    path: '/donate',
-    element: <DonatePage />,
-    loader: async () => {
-      const donatePageStrapiData = await getDonatePageStrapiData();
-      return {
-        donatePageStrapiData,
-      };
-    },
-  },
-  {
-    path: '/our-work',
-    element: <OurWorkPage />,
-    loader: async () => {
-      const ourWorkPageStrapiData = await getOurWorkPageStrapiData();
-      return {
-        ourWorkPageStrapiData,
-      };
-    },
-  },
-  {
-    path: '/our-work/training-and-advocacy',
-    element: <StatTemplatePage />,
-    loader: async () => {
-      const statTemplatePageStrapiData = await getOurWorkSubPageStrapiData(
-        OurWorkSubPages.TrainingAndAdvocacy
-      );
-      return {
-        statTemplatePageStrapiData,
-      };
-    },
-  },
-  {
-    path: '/our-work/entrepreneurship',
-    element: <StatTemplatePage />,
-    loader: async () => {
-      const statTemplatePageStrapiData = await getOurWorkSubPageStrapiData(
-        OurWorkSubPages.Entrepreneurship
-      );
-      return {
-        statTemplatePageStrapiData,
-      };
-    },
-  },
-  {
-    path: '/our-work/solar-powered-schools',
-    element: <StatTemplatePage />,
-    loader: async () => {
-      const statTemplatePageStrapiData = await getOurWorkSubPageStrapiData(
-        OurWorkSubPages.SolarPoweredSchools
-      );
-      return {
-        statTemplatePageStrapiData,
-      };
-    },
-  },
-  {
-    path: '/our-work/solar-powered-irrigation',
-    element: <StatTemplatePage />,
-    loader: async () => {
-      const statTemplatePageStrapiData = await getOurWorkSubPageStrapiData(
-        OurWorkSubPages.SolarPoweredIrrigation
-      );
-      return {
-        statTemplatePageStrapiData,
-      };
-    },
-  },
-  {
-    path: '/our-work/solar-powered-clinics',
-    element: <StatTemplatePage />,
-    loader: async () => {
-      const statTemplatePageStrapiData = await getOurWorkSubPageStrapiData(
-        OurWorkSubPages.SolarPoweredClinics
-      );
-      return {
-        statTemplatePageStrapiData,
-      };
-    },
-  },
-  {
-    path: '/our-work/cleaner-cooking',
-    element: <StatTemplatePage />,
-    loader: async () => {
-      const statTemplatePageStrapiData = await getOurWorkSubPageStrapiData(
-        OurWorkSubPages.CleanerCooking
-      );
-      return {
-        statTemplatePageStrapiData,
-      };
-    },
-  },
-]);
+const createRoutes = async () => {
+  const ourWorkSubPages: StatTemplatePagesStrapiContent =
+    await getOurWorkSubPagesStrapiData();
 
-export default router;
+  const dynamicOurWorkSubPageRoutes = ourWorkSubPages.data.map(
+    (ourWorkSubPage) => ({
+      path: `/our-work/${ourWorkSubPage.attributes.url}`,
+      element: <StatTemplatePage data={ourWorkSubPage.attributes} />,
+    })
+  );
+
+  const routes = [
+    {
+      path: '/',
+      element: <LandingPage />,
+      loader: async () => {
+        const landingPageStrapiData = await getLandingPageStrapiData();
+        return {
+          landingPageStrapiData,
+        };
+      },
+    },
+    {
+      path: '/our-mission-vision-and-values',
+      element: <OurMissionVisionAndValuesPage />,
+      loader: async () => {
+        const ourMissionVisionAndValuesStrapiData =
+          await getOurMissionVisionAndValuesPageStrapiData();
+        return {
+          ourMissionVisionAndValuesStrapiData,
+        };
+      },
+    },
+    {
+      path: '/our-team',
+      element: <OurTeamPage />,
+      loader: async () => {
+        const ourTeamPageStrapiData = await getOurTeamPageStrapiData();
+        return {
+          ourTeamPageStrapiData,
+        };
+      },
+    },
+    {
+      path: '/our-donors',
+      element: <OurDonorsPage />,
+      loader: async () => {
+        const ourDonorsPageStrapiData = await getOurDonorsPageStrapiData();
+        return {
+          ourDonorsPageStrapiData,
+        };
+      },
+    },
+    {
+      path: '/about-us',
+      element: <AboutUsPage />,
+      loader: async () => {
+        const aboutUsPageStrapiData = await getAboutUsPageStrapiData();
+        return {
+          aboutUsPageStrapiData,
+        };
+      },
+    },
+    {
+      path: '/get-involved',
+      element: <GetInvolvedPage />,
+      loader: async () => {
+        const getInvolvedPageStrapiData = await getGetInvolvedPageStrapiData();
+        return {
+          getInvolvedPageStrapiData,
+        };
+      },
+    },
+    {
+      path: '/donate',
+      element: <DonatePage />,
+      loader: async () => {
+        const donatePageStrapiData = await getDonatePageStrapiData();
+        return {
+          donatePageStrapiData,
+        };
+      },
+    },
+    {
+      path: '/our-work',
+      element: <OurWorkPage />,
+      loader: async () => {
+        const ourWorkPageStrapiData = await getOurWorkPageStrapiData();
+        return {
+          ourWorkPageStrapiData,
+        };
+      },
+    },
+    ...dynamicOurWorkSubPageRoutes,
+  ];
+
+  return createBrowserRouter(routes);
+};
+export default createRoutes;

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -9,7 +9,7 @@ import {
   getOurMissionVisionAndValuesPageStrapiData,
   getOurTeamPageStrapiData,
   getOurWorkPageStrapiData,
-  getTrainingAndAdvocacyPageStrapiData,
+  getOurWorkSubPageStrapiData,
 } from './api/strapiApi';
 import LandingPage from './pages/landing-page/LandingPage';
 import OurMissionVisionAndValuesPage from './pages/our-mission-vision-and-values-page/OurMissionVisionAndValuesPage';
@@ -20,6 +20,7 @@ import OurWorkPage from './pages/our-work-page/OurWorkPage';
 import GetInvolvedPage from './pages/get-involved-page/GetInvolvedPage';
 import DonatePage from './pages/donate-page/DonatePage';
 import StatTemplatePage from './pages/stat-template-page/StatTemplatePage';
+import { OurWorkSubPages } from './data/enums/OurWorkSubPages';
 
 const router = createBrowserRouter([
   {
@@ -32,7 +33,6 @@ const router = createBrowserRouter([
       };
     },
   },
-
   {
     path: '/our-mission-vision-and-values',
     element: <OurMissionVisionAndValuesPage />,
@@ -75,16 +75,6 @@ const router = createBrowserRouter([
     },
   },
   {
-    path: '/our-work',
-    element: <OurWorkPage />,
-    loader: async () => {
-      const ourWorkPageStrapiData = await getOurWorkPageStrapiData();
-      return {
-        ourWorkPageStrapiData,
-      };
-    },
-  },
-  {
     path: '/get-involved',
     element: <GetInvolvedPage />,
     loader: async () => {
@@ -105,11 +95,34 @@ const router = createBrowserRouter([
     },
   },
   {
-    path: '/training-and-advocacy',
+    path: '/our-work',
+    element: <OurWorkPage />,
+    loader: async () => {
+      const ourWorkPageStrapiData = await getOurWorkPageStrapiData();
+      return {
+        ourWorkPageStrapiData,
+      };
+    },
+  },
+  {
+    path: '/our-work/training-and-advocacy',
     element: <StatTemplatePage />,
     loader: async () => {
-      const statTemplatePageStrapiData =
-        await getTrainingAndAdvocacyPageStrapiData();
+      const statTemplatePageStrapiData = await getOurWorkSubPageStrapiData(
+        OurWorkSubPages.TrainingAndAdvocacy
+      );
+      return {
+        statTemplatePageStrapiData,
+      };
+    },
+  },
+  {
+    path: '/our-work/entrepreneurship',
+    element: <StatTemplatePage />,
+    loader: async () => {
+      const statTemplatePageStrapiData = await getOurWorkSubPageStrapiData(
+        OurWorkSubPages.Entrepreneurship
+      );
       return {
         statTemplatePageStrapiData,
       };

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -29,7 +29,7 @@ const createRoutes = async () => {
   const dynamicOurWorkSubPageRoutes = ourWorkSubPages.data.map(
     (ourWorkSubPage) => ({
       path: `/our-work/${ourWorkSubPage.attributes.url}`,
-      element: <StatTemplatePage data={ourWorkSubPage.attributes} />,
+      element: <StatTemplatePage strapiData={ourWorkSubPage.attributes} />,
     })
   );
 

--- a/src/test/factories/BaseCollectionFactory.ts
+++ b/src/test/factories/BaseCollectionFactory.ts
@@ -1,0 +1,40 @@
+import { EmptyMockData } from '../../data/interfaces/util/EmptyMockData';
+import { StrapiResponseCollection } from '../../data/interfaces/util/StrapiResponseCollection';
+
+abstract class BaseCollectionFactory<T> {
+  public mockResponse: StrapiResponseCollection<T>;
+  public mockData: Array<{
+    attributes: T;
+  }>;
+  public apiUrl: string;
+  public emptyMockData: EmptyMockData;
+
+  constructor(mockResponse: StrapiResponseCollection<T>, apiUrl: string) {
+    this.mockResponse = mockResponse;
+    this.mockData = mockResponse.data;
+    this.apiUrl = apiUrl;
+    this.emptyMockData = {
+      data: {
+        attributes: undefined,
+      },
+    };
+  }
+
+  public getMockResponse() {
+    return this.mockResponse;
+  }
+
+  public getMockData() {
+    return this.mockData;
+  }
+
+  public getApiUrl() {
+    return this.apiUrl;
+  }
+
+  public getEmptyMockData() {
+    return this.emptyMockData;
+  }
+}
+
+export default BaseCollectionFactory;

--- a/src/test/factories/strapi/OurWorkSubPagesFactory.ts
+++ b/src/test/factories/strapi/OurWorkSubPagesFactory.ts
@@ -1,0 +1,14 @@
+import ourWorkSubPagesStrapiResponse from '../../../../fixtures/ourWorkSubPagesStrapiResponse.json';
+import { StatTemplatePageStrapiContent } from '../../../data/interfaces/stat-template-page/StatTemplatePageStrapiContent';
+import BaseCollectionFactory from '../BaseCollectionFactory';
+
+class OurWorkSubPagesFactory extends BaseCollectionFactory<StatTemplatePageStrapiContent> {
+  constructor() {
+    super(
+      ourWorkSubPagesStrapiResponse,
+      `${import.meta.env.VITE_BASE_URL}/api/our-work-sub-pages?populate[0]=landingImage.image&populate[1]=quote&populate[2]=metrics`
+    );
+  }
+}
+
+export default OurWorkSubPagesFactory;

--- a/src/test/factories/strapi/StatTemplatePageFactory.ts
+++ b/src/test/factories/strapi/StatTemplatePageFactory.ts
@@ -1,4 +1,5 @@
 import StatTemplatePageStrapiResponse from '../../../../fixtures/statTemplatePageStrapiResponse.json';
+import { OurWorkSubPages } from '../../../data/enums/OurWorkSubPages';
 import { StatTemplatePageStrapiContent } from '../../../data/interfaces/stat-template-page/StatTemplatePageStrapiContent';
 import BaseFactory from '../BaseFactory';
 
@@ -6,7 +7,7 @@ class StatTemplatePageFactory extends BaseFactory<StatTemplatePageStrapiContent>
   constructor() {
     super(
       StatTemplatePageStrapiResponse,
-      `${import.meta.env.VITE_BASE_URL}/api/stat-template-page/1?populate[0]=landingImage.image&populate[1]=quote&populate[2]=metrics`
+      `${import.meta.env.VITE_BASE_URL}/api/our-work-sub-pages/${OurWorkSubPages.TrainingAndAdvocacy}?populate[0]=landingImage.image&populate[1]=quote&populate[2]=metrics`
     );
   }
 }

--- a/src/test/factories/strapi/StatTemplatePageFactory.ts
+++ b/src/test/factories/strapi/StatTemplatePageFactory.ts
@@ -1,14 +1,10 @@
 import StatTemplatePageStrapiResponse from '../../../../fixtures/statTemplatePageStrapiResponse.json';
-import { OurWorkSubPages } from '../../../data/enums/OurWorkSubPages';
 import { StatTemplatePageStrapiContent } from '../../../data/interfaces/stat-template-page/StatTemplatePageStrapiContent';
 import BaseFactory from '../BaseFactory';
 
 class StatTemplatePageFactory extends BaseFactory<StatTemplatePageStrapiContent> {
   constructor() {
-    super(
-      StatTemplatePageStrapiResponse,
-      `${import.meta.env.VITE_BASE_URL}/api/our-work-sub-pages/${OurWorkSubPages.TrainingAndAdvocacy}?populate[0]=landingImage.image&populate[1]=quote&populate[2]=metrics`
-    );
+    super(StatTemplatePageStrapiResponse, '');
   }
 }
 


### PR DESCRIPTION
# Context

- The previous our work sub pages implementation required coding for its routing which meant dev effort would be required anytime DR wanted to add a new page. As a result we want to add dynamic routing so DR can add pages as and when they feel. This will also likely set a lot of paradigms in the repo for the upcoming blog work.

## Changes proposed in this PR

- Update routing to allow for dynamic routing
- Update StatTemplatePage to take props
