### PR TITLE
Move non template pages off route loading

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@stripe/react-stripe-js": "^2.8.1",
         "@stripe/stripe-js": "^4.8.0",
+        "@tanstack/react-query": "^5.67.2",
         "axios": "^1.7.8",
         "bootstrap": "^5.3.3",
         "react": "^18.3.1",
@@ -1332,6 +1333,30 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.67.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.67.2.tgz",
+      "integrity": "sha512-+iaFJ/pt8TaApCk6LuZ0WHS/ECVfTzrxDOEL9HH9Dayyb5OVuomLzDXeSaI2GlGT/8HN7bDGiRXDts3LV+u6ww==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.67.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.67.2.tgz",
+      "integrity": "sha512-6Sa+BVNJWhAV4QHvIqM73norNeGRWGC3ftN0Ix87cmMvI215I1wyJ44KUTt/9a0V9YimfGcg25AITaYVel71Og==",
+      "dependencies": {
+        "@tanstack/query-core": "5.67.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@stripe/react-stripe-js": "^2.8.1",
     "@stripe/stripe-js": "^4.8.0",
+    "@tanstack/react-query": "^5.67.2",
     "axios": "^1.7.8",
     "bootstrap": "^5.3.3",
     "react": "^18.3.1",

--- a/src/data/types/LoaderData.ts
+++ b/src/data/types/LoaderData.ts
@@ -1,7 +1,5 @@
 import { LandingPageStrapiContent } from '../interfaces/landing-page/LandingPageStrapiContent';
-import { OurWorkPageStrapiContent } from '../interfaces/our-work-page/OurWorkPageStrapiContent';
 
 export type LoaderData = {
   landingPageStrapiData: LandingPageStrapiContent;
-  ourWorkPageStrapiData: OurWorkPageStrapiContent;
 };

--- a/src/data/types/LoaderData.ts
+++ b/src/data/types/LoaderData.ts
@@ -1,11 +1,9 @@
 import { DonatePageStrapiContent } from '../interfaces/donate-page/DonatePageStrapiContent';
-import { GetInvolvedPageStrapiContent } from '../interfaces/get-involved-page/GetInvolvedPageStrapiContent';
 import { LandingPageStrapiContent } from '../interfaces/landing-page/LandingPageStrapiContent';
 import { OurWorkPageStrapiContent } from '../interfaces/our-work-page/OurWorkPageStrapiContent';
 
 export type LoaderData = {
   landingPageStrapiData: LandingPageStrapiContent;
   ourWorkPageStrapiData: OurWorkPageStrapiContent;
-  getInvolvedPageStrapiData: GetInvolvedPageStrapiContent;
   donatePageStrapiData: DonatePageStrapiContent;
 };

--- a/src/data/types/LoaderData.ts
+++ b/src/data/types/LoaderData.ts
@@ -4,13 +4,11 @@ import { GetInvolvedPageStrapiContent } from '../interfaces/get-involved-page/Ge
 import { LandingPageStrapiContent } from '../interfaces/landing-page/LandingPageStrapiContent';
 import { OurDonorsPageStrapiContent } from '../interfaces/our-donor-page/OurDonorsPageStrapiContent';
 import { OurMissionVisionAndValuesPageStrapiContent } from '../interfaces/our-mission-vision-and-values-page/OurMissionVisionAndValuesPageStrapiContent';
-import { OurTeamPageStrapiContent } from '../interfaces/our-team-page/OurTeamPageStrapiContent';
 import { OurWorkPageStrapiContent } from '../interfaces/our-work-page/OurWorkPageStrapiContent';
 
 export type LoaderData = {
   landingPageStrapiData: LandingPageStrapiContent;
   ourMissionVisionAndValuesStrapiData: OurMissionVisionAndValuesPageStrapiContent;
-  ourTeamPageStrapiData: OurTeamPageStrapiContent;
   ourDonorsPageStrapiData: OurDonorsPageStrapiContent;
   aboutUsPageStrapiData: AboutUsPageStrapiContent;
   ourWorkPageStrapiData: OurWorkPageStrapiContent;

--- a/src/data/types/LoaderData.ts
+++ b/src/data/types/LoaderData.ts
@@ -3,12 +3,10 @@ import { DonatePageStrapiContent } from '../interfaces/donate-page/DonatePageStr
 import { GetInvolvedPageStrapiContent } from '../interfaces/get-involved-page/GetInvolvedPageStrapiContent';
 import { LandingPageStrapiContent } from '../interfaces/landing-page/LandingPageStrapiContent';
 import { OurDonorsPageStrapiContent } from '../interfaces/our-donor-page/OurDonorsPageStrapiContent';
-import { OurMissionVisionAndValuesPageStrapiContent } from '../interfaces/our-mission-vision-and-values-page/OurMissionVisionAndValuesPageStrapiContent';
 import { OurWorkPageStrapiContent } from '../interfaces/our-work-page/OurWorkPageStrapiContent';
 
 export type LoaderData = {
   landingPageStrapiData: LandingPageStrapiContent;
-  ourMissionVisionAndValuesStrapiData: OurMissionVisionAndValuesPageStrapiContent;
   ourDonorsPageStrapiData: OurDonorsPageStrapiContent;
   aboutUsPageStrapiData: AboutUsPageStrapiContent;
   ourWorkPageStrapiData: OurWorkPageStrapiContent;

--- a/src/data/types/LoaderData.ts
+++ b/src/data/types/LoaderData.ts
@@ -1,9 +1,7 @@
-import { DonatePageStrapiContent } from '../interfaces/donate-page/DonatePageStrapiContent';
 import { LandingPageStrapiContent } from '../interfaces/landing-page/LandingPageStrapiContent';
 import { OurWorkPageStrapiContent } from '../interfaces/our-work-page/OurWorkPageStrapiContent';
 
 export type LoaderData = {
   landingPageStrapiData: LandingPageStrapiContent;
   ourWorkPageStrapiData: OurWorkPageStrapiContent;
-  donatePageStrapiData: DonatePageStrapiContent;
 };

--- a/src/data/types/LoaderData.ts
+++ b/src/data/types/LoaderData.ts
@@ -1,4 +1,3 @@
-import { AboutUsPageStrapiContent } from '../interfaces/about-us-page/AboutUsPageStrapiContent';
 import { DonatePageStrapiContent } from '../interfaces/donate-page/DonatePageStrapiContent';
 import { GetInvolvedPageStrapiContent } from '../interfaces/get-involved-page/GetInvolvedPageStrapiContent';
 import { LandingPageStrapiContent } from '../interfaces/landing-page/LandingPageStrapiContent';
@@ -6,7 +5,6 @@ import { OurWorkPageStrapiContent } from '../interfaces/our-work-page/OurWorkPag
 
 export type LoaderData = {
   landingPageStrapiData: LandingPageStrapiContent;
-  aboutUsPageStrapiData: AboutUsPageStrapiContent;
   ourWorkPageStrapiData: OurWorkPageStrapiContent;
   getInvolvedPageStrapiData: GetInvolvedPageStrapiContent;
   donatePageStrapiData: DonatePageStrapiContent;

--- a/src/data/types/LoaderData.ts
+++ b/src/data/types/LoaderData.ts
@@ -2,12 +2,10 @@ import { AboutUsPageStrapiContent } from '../interfaces/about-us-page/AboutUsPag
 import { DonatePageStrapiContent } from '../interfaces/donate-page/DonatePageStrapiContent';
 import { GetInvolvedPageStrapiContent } from '../interfaces/get-involved-page/GetInvolvedPageStrapiContent';
 import { LandingPageStrapiContent } from '../interfaces/landing-page/LandingPageStrapiContent';
-import { OurDonorsPageStrapiContent } from '../interfaces/our-donor-page/OurDonorsPageStrapiContent';
 import { OurWorkPageStrapiContent } from '../interfaces/our-work-page/OurWorkPageStrapiContent';
 
 export type LoaderData = {
   landingPageStrapiData: LandingPageStrapiContent;
-  ourDonorsPageStrapiData: OurDonorsPageStrapiContent;
   aboutUsPageStrapiData: AboutUsPageStrapiContent;
   ourWorkPageStrapiData: OurWorkPageStrapiContent;
   getInvolvedPageStrapiData: GetInvolvedPageStrapiContent;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,16 +3,21 @@ import React, { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { RouterProvider } from 'react-router-dom';
 import Loading from './components/loading/Loading';
-import './index.scss';
 import { SharedDataProvider } from './contexts/SharedDataProvider';
 import createRoutes from './routes';
+import './index.scss';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const queryClient = new QueryClient();
 
 createRoutes().then((router) => {
   createRoot(document.getElementById('root')!).render(
     <StrictMode>
-      <SharedDataProvider>
-        <RouterProvider router={router} fallbackElement={<Loading />} />
-      </SharedDataProvider>
+      <QueryClientProvider client={queryClient}>
+        <SharedDataProvider>
+          <RouterProvider router={router} fallbackElement={<Loading />} />
+        </SharedDataProvider>
+      </QueryClientProvider>
     </StrictMode>
   );
 });

--- a/src/pages/about-us-page/AboutUsPage.tsx
+++ b/src/pages/about-us-page/AboutUsPage.tsx
@@ -1,32 +1,37 @@
 import React from 'react';
 import PageWrapper from '../../components/page-wrapper/PageWrapper';
 import { Row, Col } from 'react-bootstrap';
-import { useLoaderData } from 'react-router-dom';
-import { LoaderData } from '../../data/types/LoaderData';
 import AboutUsPageSection from '../../components/about-us-page/about-us-page-section/AboutUsPageSection';
 import AboutUsPageImageButtonsSection from '../../components/about-us-page/about-us-page-image-buttons-section/aboutUsPageImageButtonsSection';
 import LandingCardDesktop from '../../components/landing-card/desktop/LandingCardDesktop';
 import LandingCardMobile from '../../components/landing-card/mobile/landingCardMobile';
+import { useQuery } from '@tanstack/react-query';
+import { getAboutUsPageStrapiData } from '../../api/strapiApi';
+import Loading from '../../components/loading/Loading';
+import { AboutUsPageStrapiContent } from '../../data/interfaces/about-us-page/AboutUsPageStrapiContent';
 
 const AboutUsPage: React.FC = () => {
-  const { aboutUsPageStrapiData } = useLoaderData() as LoaderData;
+  const { data, isPending, error } = useQuery<AboutUsPageStrapiContent>({
+    queryKey: ['aboutUsPage'],
+    queryFn: getAboutUsPageStrapiData,
+  });
+
+  if (isPending) return <Loading />;
+  if (error || !data) return <p>Error Loading Data</p>;
+
   return (
     <PageWrapper>
       <Row>
         <Col>
           <div className="d-none d-sm-block mb-5">
-            <LandingCardDesktop
-              landingCard={aboutUsPageStrapiData.landingImage}
-            />
+            <LandingCardDesktop landingCard={data.landingImage} />
           </div>
           <div className="d-sm-none">
-            <LandingCardMobile
-              landingCard={aboutUsPageStrapiData.landingImage}
-            />
+            <LandingCardMobile landingCard={data.landingImage} />
           </div>
         </Col>
       </Row>
-      {aboutUsPageStrapiData.sections.map((section, index) => (
+      {data.sections.map((section, index) => (
         <Row key={index} className="mb-5">
           <Col>
             <AboutUsPageSection sectionData={section} rowIndex={index} />
@@ -36,7 +41,7 @@ const AboutUsPage: React.FC = () => {
       <Row className="mb-5">
         <Col>
           <AboutUsPageImageButtonsSection
-            imageButtonSectionData={aboutUsPageStrapiData.imageButtonSection}
+            imageButtonSectionData={data.imageButtonSection}
           />
         </Col>
       </Row>

--- a/src/pages/about-us-page/aboutUsPage.test.tsx
+++ b/src/pages/about-us-page/aboutUsPage.test.tsx
@@ -1,6 +1,5 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import React from 'react';
-import { MemoryRouter, useLoaderData } from 'react-router-dom';
 import {
   afterEach,
   beforeEach,
@@ -10,42 +9,22 @@ import {
   test,
   vi,
 } from 'vitest';
-import navigationBarFactory from '../../test/factories/strapi/NavigationBarFactory';
-import FooterFactory from '../../test/factories/strapi/FooterFactory';
-import { SharedDataContext } from '../../contexts/SharedDataProvider';
 import AboutUsPageFactory from '../../test/factories/strapi/AboutUsPageFactory';
 import AboutUsPage from './AboutUsPage';
-
-vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual('react-router-dom');
-  return {
-    ...actual,
-    useLoaderData: vi.fn(),
-  };
-});
+import { useQuery } from '@tanstack/react-query';
+import { renderWithProviders } from '../../test/helpers/helpers';
 
 describe('AboutUsPage', () => {
-  const mockLoaderData = {
-    aboutUsPageStrapiData: new AboutUsPageFactory().getMockData(),
-  };
-
-  const navigationBarStrapiData = new navigationBarFactory().getMockData();
-  const footerStrapiData = new FooterFactory().getMockData();
+  const mockData = new AboutUsPageFactory().getMockData();
 
   const setup = async () => {
-    (useLoaderData as Mock).mockReturnValue(mockLoaderData);
-    render(
-      <SharedDataContext.Provider
-        value={{
-          navigationBarContent: navigationBarStrapiData,
-          footerContent: footerStrapiData,
-        }}
-      >
-        <MemoryRouter>
-          <AboutUsPage />
-        </MemoryRouter>
-      </SharedDataContext.Provider>
-    );
+    (vi.mocked(useQuery) as Mock).mockReturnValue({
+      data: mockData,
+      isLoading: false,
+      error: null,
+    });
+
+    renderWithProviders(<AboutUsPage />);
   };
 
   beforeEach(() => {

--- a/src/pages/blog-home-page/BlogHomePage.tsx
+++ b/src/pages/blog-home-page/BlogHomePage.tsx
@@ -3,12 +3,23 @@ import PageWrapper from '../../components/page-wrapper/PageWrapper';
 import { BlogPostsTemplatePageStrapiContent } from '../../data/interfaces/blog-post-template-page/BlogPostTemplatePagesStrapiContent';
 import { Col, Row } from 'react-bootstrap';
 import BlogCard from '../../components/blog-card/BlogCard';
+import { useQuery } from '@tanstack/react-query';
+import { getBlogPostsStrapiData } from '../../api/strapiApi';
+import Loading from '../../components/loading/Loading';
+import { sortBlogPostsNewestToOldest } from '../../util/blogHelper';
 
-type Props = {
-  blogPages: BlogPostsTemplatePageStrapiContent;
-};
+const BlogHomePage: React.FC = () => {
+  const { data, isPending, error } =
+    useQuery<BlogPostsTemplatePageStrapiContent>({
+      queryKey: ['blogHomePage'],
+      queryFn: getBlogPostsStrapiData,
+    });
 
-const BlogHomePage: React.FC<Props> = ({ blogPages }) => {
+  if (isPending) return <Loading />;
+  if (error || !data) return <p>Error Loading Data</p>;
+
+  const blogPosts = sortBlogPostsNewestToOldest(data);
+
   return (
     <PageWrapper>
       <Row>
@@ -19,7 +30,7 @@ const BlogHomePage: React.FC<Props> = ({ blogPages }) => {
         </Col>
       </Row>
       <Row data-testid="blog-grid">
-        {blogPages.data.map((post, index) => (
+        {blogPosts.map((post, index) => (
           <Col
             key={index}
             xl={4}

--- a/src/pages/blog-home-page/blogHomePage.test.tsx
+++ b/src/pages/blog-home-page/blogHomePage.test.tsx
@@ -1,31 +1,30 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import React from 'react';
-import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
-import { MemoryRouter } from 'react-router-dom';
+import {
+  describe,
+  test,
+  expect,
+  beforeEach,
+  afterEach,
+  vi,
+  Mock,
+} from 'vitest';
 import BlogHomePage from './BlogHomePage';
 import BlogPostsFactory from '../../test/factories/strapi/BlogPostsFactory';
-import { SharedDataContext } from '../../contexts/SharedDataProvider';
-import navigationBarFactory from '../../test/factories/strapi/NavigationBarFactory';
-import FooterFactory from '../../test/factories/strapi/FooterFactory';
+import { useQuery } from '@tanstack/react-query';
+import { renderWithProviders } from '../../test/helpers/helpers';
 
 describe('BlogHomePage', () => {
-  const mockBlogData = new BlogPostsFactory().getMockData();
-  const navigationBarStrapiData = new navigationBarFactory().getMockData();
-  const footerStrapiData = new FooterFactory().getMockData();
+  const mockData = new BlogPostsFactory().getMockData();
 
-  const setup = () => {
-    render(
-      <SharedDataContext.Provider
-        value={{
-          navigationBarContent: navigationBarStrapiData,
-          footerContent: footerStrapiData,
-        }}
-      >
-        <MemoryRouter>
-          <BlogHomePage blogPages={{ data: mockBlogData }} />
-        </MemoryRouter>
-      </SharedDataContext.Provider>
-    );
+  const setup = async () => {
+    (vi.mocked(useQuery) as Mock).mockReturnValue({
+      data: { data: mockData },
+      isLoading: false,
+      error: null,
+    });
+
+    renderWithProviders(<BlogHomePage />);
   };
 
   beforeEach(() => {
@@ -44,7 +43,7 @@ describe('BlogHomePage', () => {
       setup();
       await waitFor(() => {
         expect(screen.getAllByTestId('blog-card')).toHaveLength(
-          mockBlogData.length
+          mockData.length
         );
       });
     });
@@ -52,7 +51,7 @@ describe('BlogHomePage', () => {
     test('should render each blog card with correct data', async () => {
       setup();
       await waitFor(() => {
-        mockBlogData.forEach((post) => {
+        mockData.forEach((post) => {
           expect(
             screen.getByTestId(`blog-card-landing-image-${post.attributes.url}`)
           ).toBeInTheDocument();

--- a/src/pages/donate-page/DonatePage.tsx
+++ b/src/pages/donate-page/DonatePage.tsx
@@ -3,35 +3,42 @@ import { Col, Row } from 'react-bootstrap';
 import PageWrapper from '../../components/page-wrapper/PageWrapper';
 import LandingCardDesktop from '../../components/landing-card/desktop/LandingCardDesktop';
 import LandingCardMobile from '../../components/landing-card/mobile/landingCardMobile';
-import { useLoaderData } from 'react-router-dom';
-import { LoaderData } from '../../data/types/LoaderData';
 import DonatePagePaymentSection from '../../components/donate-page/donate-page-payment-section/DonatePagePaymentSection';
 import Metric from '../../components/metric/Metric';
+import { useQuery } from '@tanstack/react-query';
+import { getDonatePageStrapiData } from '../../api/strapiApi';
+import Loading from '../../components/loading/Loading';
+import { DonatePageStrapiContent } from '../../data/interfaces/donate-page/DonatePageStrapiContent';
 
 const DonatePage: React.FC = () => {
-  const { donatePageStrapiData } = useLoaderData() as LoaderData;
+  const { data, isPending, error } = useQuery<DonatePageStrapiContent>({
+    queryKey: ['donatePage'],
+    queryFn: getDonatePageStrapiData,
+  });
+
+  if (isPending) return <Loading />;
+  if (error || !data) return <p>Error Loading Data</p>;
+
   return (
     <PageWrapper>
       <Row className="mb-5">
         <Col xs={12} lg={7}>
           <div className="d-none d-sm-block mb-5">
-            <LandingCardDesktop
-              landingCard={donatePageStrapiData.landingCard}
-            />
+            <LandingCardDesktop landingCard={data.landingCard} />
           </div>
           <div className="d-sm-none">
-            <LandingCardMobile landingCard={donatePageStrapiData.landingCard} />
+            <LandingCardMobile landingCard={data.landingCard} />
           </div>
           <div className="mt-5 mt-lg-3 px-3 px-lg-5">
             <p
               data-testid="donate-page-pre-metric-text"
               className=" fs-3 text-center text-lg-start"
             >
-              {donatePageStrapiData.preMetricText}
+              {data.preMetricText}
             </p>
           </div>
           <Row>
-            {donatePageStrapiData.metrics.map((metric, index) => (
+            {data.metrics.map((metric, index) => (
               <Col key={index} xl="6" sm="12">
                 <Metric metricData={metric} />
               </Col>
@@ -42,14 +49,12 @@ const DonatePage: React.FC = () => {
               data-testid="donate-page-post-metric-text"
               className=" fs-3 text-center text-lg-start"
             >
-              {donatePageStrapiData.preMetricText}
+              {data.preMetricText}
             </p>
           </div>
         </Col>
         <Col xs={12} lg={5}>
-          <DonatePagePaymentSection
-            paymentStrapiData={donatePageStrapiData.paymentSection}
-          />
+          <DonatePagePaymentSection paymentStrapiData={data.paymentSection} />
         </Col>
       </Row>
     </PageWrapper>

--- a/src/pages/donate-page/donatePage.test.tsx
+++ b/src/pages/donate-page/donatePage.test.tsx
@@ -1,6 +1,5 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import React from 'react';
-import { MemoryRouter, useLoaderData } from 'react-router-dom';
 import {
   afterEach,
   beforeEach,
@@ -10,42 +9,22 @@ import {
   test,
   vi,
 } from 'vitest';
-import navigationBarFactory from '../../test/factories/strapi/NavigationBarFactory';
-import FooterFactory from '../../test/factories/strapi/FooterFactory';
-import { SharedDataContext } from '../../contexts/SharedDataProvider';
 import DonatePageFactory from '../../test/factories/strapi/DonatePageFactory';
 import DonatePage from './DonatePage';
-
-vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual('react-router-dom');
-  return {
-    ...actual,
-    useLoaderData: vi.fn(),
-  };
-});
+import { useQuery } from '@tanstack/react-query';
+import { renderWithProviders } from '../../test/helpers/helpers';
 
 describe('DonatePage', () => {
-  const mockLoaderData = {
-    donatePageStrapiData: new DonatePageFactory().getMockData(),
-  };
-
-  const navigationBarStrapiData = new navigationBarFactory().getMockData();
-  const footerStrapiData = new FooterFactory().getMockData();
+  const mockData = new DonatePageFactory().getMockData();
 
   const setup = async () => {
-    (useLoaderData as Mock).mockReturnValue(mockLoaderData);
-    render(
-      <SharedDataContext.Provider
-        value={{
-          navigationBarContent: navigationBarStrapiData,
-          footerContent: footerStrapiData,
-        }}
-      >
-        <MemoryRouter>
-          <DonatePage />
-        </MemoryRouter>
-      </SharedDataContext.Provider>
-    );
+    (vi.mocked(useQuery) as Mock).mockReturnValue({
+      data: mockData,
+      isLoading: false,
+      error: null,
+    });
+
+    renderWithProviders(<DonatePage />);
   };
 
   beforeEach(() => {

--- a/src/pages/get-involved-page/GetInvolvedPage.tsx
+++ b/src/pages/get-involved-page/GetInvolvedPage.tsx
@@ -1,32 +1,37 @@
 import React from 'react';
 import { Col, Row } from 'react-bootstrap';
 import PageWrapper from '../../components/page-wrapper/PageWrapper';
-import { useLoaderData } from 'react-router-dom';
 import LandingCardDesktop from '../../components/landing-card/desktop/LandingCardDesktop';
 import LandingCardMobile from '../../components/landing-card/mobile/landingCardMobile';
-import { LoaderData } from '../../data/types/LoaderData';
 import GetInvolvedPageSection from '../../components/get-involved-page/get-involved-page-section/GetInvolvedPageSection';
 import PaymentSection from '../../components/payment/payment-section/PaymentSection';
+import { useQuery } from '@tanstack/react-query';
+import { getGetInvolvedPageStrapiData } from '../../api/strapiApi';
+import Loading from '../../components/loading/Loading';
+import { GetInvolvedPageStrapiContent } from '../../data/interfaces/get-involved-page/GetInvolvedPageStrapiContent';
 
 const GetInvolvedPage: React.FC = () => {
-  const { getInvolvedPageStrapiData } = useLoaderData() as LoaderData;
+  const { data, isPending, error } = useQuery<GetInvolvedPageStrapiContent>({
+    queryKey: ['getInvolvedPage'],
+    queryFn: getGetInvolvedPageStrapiData,
+  });
+
+  if (isPending) return <Loading />;
+  if (error || !data) return <p>Error Loading Data</p>;
+
   return (
     <PageWrapper>
       <Row>
         <Col>
           <div className="d-none d-sm-block mb-5">
-            <LandingCardDesktop
-              landingCard={getInvolvedPageStrapiData.landingCard}
-            />
+            <LandingCardDesktop landingCard={data.landingCard} />
           </div>
           <div className="d-sm-none">
-            <LandingCardMobile
-              landingCard={getInvolvedPageStrapiData.landingCard}
-            />
+            <LandingCardMobile landingCard={data.landingCard} />
           </div>
         </Col>
       </Row>
-      {getInvolvedPageStrapiData.sections.map((section, index) => (
+      {data.sections.map((section, index) => (
         <Row key={index} className="mb-5">
           <Col>
             <GetInvolvedPageSection sectionData={section} rowIndex={index} />
@@ -35,9 +40,7 @@ const GetInvolvedPage: React.FC = () => {
       ))}
       <Row>
         <Col>
-          <PaymentSection
-            paymentData={getInvolvedPageStrapiData.paymentSection}
-          />
+          <PaymentSection paymentData={data.paymentSection} />
         </Col>
       </Row>
     </PageWrapper>

--- a/src/pages/get-involved-page/getInvolvedPage.test.tsx
+++ b/src/pages/get-involved-page/getInvolvedPage.test.tsx
@@ -1,6 +1,5 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import React from 'react';
-import { MemoryRouter, useLoaderData } from 'react-router-dom';
 import {
   afterEach,
   beforeEach,
@@ -10,42 +9,22 @@ import {
   test,
   vi,
 } from 'vitest';
-import navigationBarFactory from '../../test/factories/strapi/NavigationBarFactory';
-import FooterFactory from '../../test/factories/strapi/FooterFactory';
-import { SharedDataContext } from '../../contexts/SharedDataProvider';
 import GetInvolvedPageFactory from '../../test/factories/strapi/GetInvolvedPageFactory';
 import GetInvolvedPage from './GetInvolvedPage';
-
-vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual('react-router-dom');
-  return {
-    ...actual,
-    useLoaderData: vi.fn(),
-  };
-});
+import { useQuery } from '@tanstack/react-query';
+import { renderWithProviders } from '../../test/helpers/helpers';
 
 describe('GetInvolvedPage', () => {
-  const mockLoaderData = {
-    getInvolvedPageStrapiData: new GetInvolvedPageFactory().getMockData(),
-  };
-
-  const navigationBarStrapiData = new navigationBarFactory().getMockData();
-  const footerStrapiData = new FooterFactory().getMockData();
+  const mockData = new GetInvolvedPageFactory().getMockData();
 
   const setup = async () => {
-    (useLoaderData as Mock).mockReturnValue(mockLoaderData);
-    render(
-      <SharedDataContext.Provider
-        value={{
-          navigationBarContent: navigationBarStrapiData,
-          footerContent: footerStrapiData,
-        }}
-      >
-        <MemoryRouter>
-          <GetInvolvedPage />
-        </MemoryRouter>
-      </SharedDataContext.Provider>
-    );
+    (vi.mocked(useQuery) as Mock).mockReturnValue({
+      data: mockData,
+      isLoading: false,
+      error: null,
+    });
+
+    renderWithProviders(<GetInvolvedPage />);
   };
 
   beforeEach(() => {

--- a/src/pages/our-donors-page/OurDonorsPage.tsx
+++ b/src/pages/our-donors-page/OurDonorsPage.tsx
@@ -1,30 +1,39 @@
 import React from 'react';
 import PageWrapper from '../../components/page-wrapper/PageWrapper';
-import { useLoaderData } from 'react-router-dom';
-import { LoaderData } from '../../data/types/LoaderData';
 import OurDonorsPageDonor from '../../components/our-donors-page/ourDonorsPageDonor';
 import { Col, Row } from 'react-bootstrap';
+import { useQuery } from '@tanstack/react-query';
+import { getOurDonorsPageStrapiData } from '../../api/strapiApi';
+import Loading from '../../components/loading/Loading';
+import { OurDonorsPageStrapiContent } from '../../data/interfaces/our-donor-page/OurDonorsPageStrapiContent';
 
 const OurDonorsPage: React.FC = () => {
-  const { ourDonorsPageStrapiData } = useLoaderData() as LoaderData;
+  const { data, isPending, error } = useQuery<OurDonorsPageStrapiContent>({
+    queryKey: ['ourDonorsPage'],
+    queryFn: getOurDonorsPageStrapiData,
+  });
+
+  if (isPending) return <Loading />;
+  if (error || !data) return <p>Error Loading Data</p>;
+
   return (
     <PageWrapper>
       <Row className="mt-5 mb-2">
         <Col className="text-center">
           <h1 data-testid="our-donors-page-title" className="fs-1 fw-bold">
-            {ourDonorsPageStrapiData.pageTitle}
+            {data.pageTitle}
           </h1>
         </Col>
       </Row>
       <Row className="mb-5">
         <Col className="text-center">
           <h2 data-testid="our-donors-page-sub-title" className="fs-4">
-            {ourDonorsPageStrapiData.pageSubTitle}
+            {data.pageSubTitle}
           </h2>
         </Col>
       </Row>
       <Row className="d-flex justify-content-center">
-        {ourDonorsPageStrapiData.ourDonors.map((donor, index) => (
+        {data.ourDonors.map((donor, index) => (
           <Col xl="3" md="4" xs="12" key={index}>
             <OurDonorsPageDonor ourDonor={donor} />
           </Col>

--- a/src/pages/our-donors-page/ourDonorsPage.test.tsx
+++ b/src/pages/our-donors-page/ourDonorsPage.test.tsx
@@ -1,6 +1,5 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import React from 'react';
-import { MemoryRouter, useLoaderData } from 'react-router-dom';
 import {
   afterEach,
   beforeEach,
@@ -10,42 +9,22 @@ import {
   test,
   vi,
 } from 'vitest';
-import navigationBarFactory from '../../test/factories/strapi/NavigationBarFactory';
-import FooterFactory from '../../test/factories/strapi/FooterFactory';
 import OurDonorPageFactory from '../../test/factories/strapi/OurDonorPageFactory';
 import OurDonorsPage from './OurDonorsPage';
-import { SharedDataContext } from '../../contexts/SharedDataProvider';
-
-vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual('react-router-dom');
-  return {
-    ...actual,
-    useLoaderData: vi.fn(),
-  };
-});
+import { useQuery } from '@tanstack/react-query';
+import { renderWithProviders } from '../../test/helpers/helpers';
 
 describe('OurDonorsPage', () => {
-  const mockLoaderData = {
-    ourDonorsPageStrapiData: new OurDonorPageFactory().getMockData(),
-  };
-
-  const navigationBarStrapiData = new navigationBarFactory().getMockData();
-  const footerStrapiData = new FooterFactory().getMockData();
+  const mockData = new OurDonorPageFactory().getMockData();
 
   const setup = async () => {
-    (useLoaderData as Mock).mockReturnValue(mockLoaderData);
-    render(
-      <SharedDataContext.Provider
-        value={{
-          navigationBarContent: navigationBarStrapiData,
-          footerContent: footerStrapiData,
-        }}
-      >
-        <MemoryRouter>
-          <OurDonorsPage />
-        </MemoryRouter>
-      </SharedDataContext.Provider>
-    );
+    (vi.mocked(useQuery) as Mock).mockReturnValue({
+      data: mockData,
+      isLoading: false,
+      error: null,
+    });
+
+    renderWithProviders(<OurDonorsPage />);
   };
 
   beforeEach(() => {

--- a/src/pages/our-mission-vision-and-values-page/OurMissionVisionAndValuesPage.tsx
+++ b/src/pages/our-mission-vision-and-values-page/OurMissionVisionAndValuesPage.tsx
@@ -12,7 +12,7 @@ import { OurMissionVisionAndValuesPageStrapiContent } from '../../data/interface
 const OurMissionVisionAndValuesPage: React.FC = () => {
   const { data, isPending, error } =
     useQuery<OurMissionVisionAndValuesPageStrapiContent>({
-      queryKey: ['ourTeamPage'],
+      queryKey: ['ourMissionVisionAndValuesPageStrapiContent'],
       queryFn: getOurMissionVisionAndValuesPageStrapiData,
     });
 

--- a/src/pages/our-mission-vision-and-values-page/OurMissionVisionAndValuesPage.tsx
+++ b/src/pages/our-mission-vision-and-values-page/OurMissionVisionAndValuesPage.tsx
@@ -1,55 +1,54 @@
 import React from 'react';
-import { useLoaderData } from 'react-router-dom';
-import { LoaderData } from '../../data/types/LoaderData';
 import PageWrapper from '../../components/page-wrapper/PageWrapper';
 import OurMissionVisionAndValuesPageMissionSection from '../../components/our-mission-vision-and-values-page/our-mission-vision-and-values-page-mission-section/OurMissionVisionAndValuesPageMissionSection';
 import OurMissionVisionAndValuesPageVisionSection from '../../components/our-mission-vision-and-values-page/our-mission-vision-and-values-page-vision-section/OurMissionVisionAndValuesPageVisionSection';
 import OurMissionVisionAndValuesPageValuesSection from '../../components/our-mission-vision-and-values-page/our-mission-vision-and-values-page-values-section/OurMissionVisionAndValuesPageValuesSection';
+import Loading from '../../components/loading/Loading';
 import { Col, Row } from 'react-bootstrap';
+import { useQuery } from '@tanstack/react-query';
+import { getOurMissionVisionAndValuesPageStrapiData } from '../../api/strapiApi';
+import { OurMissionVisionAndValuesPageStrapiContent } from '../../data/interfaces/our-mission-vision-and-values-page/OurMissionVisionAndValuesPageStrapiContent';
 
 const OurMissionVisionAndValuesPage: React.FC = () => {
-  const { ourMissionVisionAndValuesStrapiData } = useLoaderData() as LoaderData;
+  const { data, isPending, error } =
+    useQuery<OurMissionVisionAndValuesPageStrapiContent>({
+      queryKey: ['ourTeamPage'],
+      queryFn: getOurMissionVisionAndValuesPageStrapiData,
+    });
+
+  if (isPending) return <Loading />;
+  if (error || !data) return <p>Error Loading Data</p>;
 
   return (
     <PageWrapper>
       <Row className="mt-5 mb-2">
         <Col className="text-center">
-          <h1 className="fs-1 fw-bold">
-            {ourMissionVisionAndValuesStrapiData.pageTitle}
-          </h1>
+          <h1 className="fs-1 fw-bold">{data.pageTitle}</h1>
         </Col>
       </Row>
       <Row className="mb-3">
         <Col className="text-center">
-          <p className="fs-4">
-            {ourMissionVisionAndValuesStrapiData.pageSubTitle}
-          </p>
+          <p className="fs-4">{data.pageSubTitle}</p>
         </Col>
       </Row>
       <Row>
         <Col>
           <OurMissionVisionAndValuesPageMissionSection
-            ourMissionSection={
-              ourMissionVisionAndValuesStrapiData.ourMissionSection
-            }
+            ourMissionSection={data.ourMissionSection}
           />
         </Col>
       </Row>
       <Row>
         <Col>
           <OurMissionVisionAndValuesPageVisionSection
-            ourVisionSection={
-              ourMissionVisionAndValuesStrapiData.ourVisionSection
-            }
+            ourVisionSection={data.ourVisionSection}
           />
         </Col>
       </Row>
       <Row>
         <Col>
           <OurMissionVisionAndValuesPageValuesSection
-            ourValuesSection={
-              ourMissionVisionAndValuesStrapiData.ourValuesSection
-            }
+            ourValuesSection={data.ourValuesSection}
           />
         </Col>
       </Row>

--- a/src/pages/our-mission-vision-and-values-page/ourMissionVisionAndValuesPage.test.tsx
+++ b/src/pages/our-mission-vision-and-values-page/ourMissionVisionAndValuesPage.test.tsx
@@ -1,6 +1,5 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import React from 'react';
-import { MemoryRouter, useLoaderData } from 'react-router-dom';
 import {
   afterEach,
   beforeEach,
@@ -10,43 +9,22 @@ import {
   test,
   vi,
 } from 'vitest';
-import navigationBarFactory from '../../test/factories/strapi/NavigationBarFactory';
-import FooterFactory from '../../test/factories/strapi/FooterFactory';
 import OurMissionVisionAndValuesPageFactory from '../../test/factories/strapi/OurMissionVisionAndValuesPageFactory';
 import OurMissionVisionAndValuesPage from './OurMissionVisionAndValuesPage';
-import { SharedDataContext } from '../../contexts/SharedDataProvider';
-
-vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual('react-router-dom');
-  return {
-    ...actual,
-    useLoaderData: vi.fn(),
-  };
-});
+import { useQuery } from '@tanstack/react-query';
+import { renderWithProviders } from '../../test/helpers/helpers';
 
 describe('OurMissionVisionAndValuesPage', () => {
-  const mockLoaderData = {
-    ourMissionVisionAndValuesStrapiData:
-      new OurMissionVisionAndValuesPageFactory().getMockData(),
-  };
-
-  const navigationBarStrapiData = new navigationBarFactory().getMockData();
-  const footerStrapiData = new FooterFactory().getMockData();
+  const mockData = new OurMissionVisionAndValuesPageFactory().getMockData();
 
   const setup = async () => {
-    (useLoaderData as Mock).mockReturnValue(mockLoaderData);
-    render(
-      <SharedDataContext.Provider
-        value={{
-          navigationBarContent: navigationBarStrapiData,
-          footerContent: footerStrapiData,
-        }}
-      >
-        <MemoryRouter>
-          <OurMissionVisionAndValuesPage />
-        </MemoryRouter>
-      </SharedDataContext.Provider>
-    );
+    (vi.mocked(useQuery) as Mock).mockReturnValue({
+      data: mockData,
+      isLoading: false,
+      error: null,
+    });
+
+    renderWithProviders(<OurMissionVisionAndValuesPage />);
   };
 
   beforeEach(() => {

--- a/src/pages/our-team-page/OurTeamPage.tsx
+++ b/src/pages/our-team-page/OurTeamPage.tsx
@@ -1,39 +1,45 @@
 import React from 'react';
 import PageWrapper from '../../components/page-wrapper/PageWrapper';
-import { LoaderData } from '../../data/types/LoaderData';
-import { useLoaderData } from 'react-router-dom';
 import OurTeamPageDepartmentSection from '../../components/our-team-page/OurTeamPageDepartmentSection';
 import { Col, Row } from 'react-bootstrap';
+import { useQuery } from '@tanstack/react-query';
+import { getOurTeamPageStrapiData } from '../../api/strapiApi';
+import Loading from '../../components/loading/Loading';
+import { OurTeamPageStrapiContent } from '../../data/interfaces/our-team-page/OurTeamPageStrapiContent';
 
 const OurTeamPage: React.FC = () => {
-  const { ourTeamPageStrapiData } = useLoaderData() as LoaderData;
+  const { data, isPending, error } = useQuery<OurTeamPageStrapiContent>({
+    queryKey: ['ourTeamPage'],
+    queryFn: getOurTeamPageStrapiData,
+  });
+
+  if (isPending) return <Loading />;
+  if (error || !data) return <p>Error Loading Data</p>;
 
   return (
     <PageWrapper>
       <Row className="mt-5 mb-2">
         <Col className="text-center">
           <h1 data-testid="our-team-page-title" className="fs-1 fw-bold">
-            {ourTeamPageStrapiData.pageTitle}
+            {data.pageTitle}
           </h1>
         </Col>
       </Row>
       <Row className="mb-5">
         <Col className="text-center">
           <h2 data-testid="our-team-page-sub-title" className="fs-4">
-            {ourTeamPageStrapiData.pageSubTitle}
+            {data.pageSubTitle}
           </h2>
         </Col>
       </Row>
       <Row>
         <Col>
-          {ourTeamPageStrapiData.departmentSections.map(
-            (departmentSection, index) => (
-              <OurTeamPageDepartmentSection
-                key={index}
-                departmentSection={departmentSection}
-              />
-            )
-          )}
+          {data.departmentSections.map((departmentSection, index) => (
+            <OurTeamPageDepartmentSection
+              key={index}
+              departmentSection={departmentSection}
+            />
+          ))}
         </Col>
       </Row>
     </PageWrapper>

--- a/src/pages/our-team-page/ourTeamPage.test.tsx
+++ b/src/pages/our-team-page/ourTeamPage.test.tsx
@@ -1,6 +1,5 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import React from 'react';
-import { MemoryRouter, useLoaderData } from 'react-router-dom';
 import {
   afterEach,
   beforeEach,
@@ -10,42 +9,22 @@ import {
   test,
   vi,
 } from 'vitest';
-import navigationBarFactory from '../../test/factories/strapi/NavigationBarFactory';
-import FooterFactory from '../../test/factories/strapi/FooterFactory';
 import OurTeamPageFactory from '../../test/factories/strapi/OurTeamPageFactory';
 import OurTeamPage from './OurTeamPage';
-import { SharedDataContext } from '../../contexts/SharedDataProvider';
-
-vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual('react-router-dom');
-  return {
-    ...actual,
-    useLoaderData: vi.fn(),
-  };
-});
+import { useQuery } from '@tanstack/react-query';
+import { renderWithProviders } from '../../test/helpers/helpers';
 
 describe('OurTeamPage', () => {
-  const mockLoaderData = {
-    ourTeamPageStrapiData: new OurTeamPageFactory().getMockData(),
-  };
-
-  const navigationBarStrapiData = new navigationBarFactory().getMockData();
-  const footerStrapiData = new FooterFactory().getMockData();
+  const mockData = new OurTeamPageFactory().getMockData();
 
   const setup = async () => {
-    (useLoaderData as Mock).mockReturnValue(mockLoaderData);
-    render(
-      <SharedDataContext.Provider
-        value={{
-          navigationBarContent: navigationBarStrapiData,
-          footerContent: footerStrapiData,
-        }}
-      >
-        <MemoryRouter>
-          <OurTeamPage />
-        </MemoryRouter>
-      </SharedDataContext.Provider>
-    );
+    (vi.mocked(useQuery) as Mock).mockReturnValue({
+      data: mockData,
+      isLoading: false,
+      error: null,
+    });
+
+    renderWithProviders(<OurTeamPage />);
   };
 
   beforeEach(() => {

--- a/src/pages/our-work-page/OurWorkPage.test.tsx
+++ b/src/pages/our-work-page/OurWorkPage.test.tsx
@@ -1,6 +1,5 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import React from 'react';
-import { MemoryRouter, useLoaderData } from 'react-router-dom';
 import {
   afterEach,
   beforeEach,
@@ -10,42 +9,22 @@ import {
   test,
   vi,
 } from 'vitest';
-import navigationBarFactory from '../../test/factories/strapi/NavigationBarFactory';
-import FooterFactory from '../../test/factories/strapi/FooterFactory';
-import { SharedDataContext } from '../../contexts/SharedDataProvider';
 import OurWorkPageFactory from '../../test/factories/strapi/OurWorkPageFactory';
 import OurWorkPage from './OurWorkPage';
-
-vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual('react-router-dom');
-  return {
-    ...actual,
-    useLoaderData: vi.fn(),
-  };
-});
+import { useQuery } from '@tanstack/react-query';
+import { renderWithProviders } from '../../test/helpers/helpers';
 
 describe('OurWorkPage', () => {
-  const mockLoaderData = {
-    ourWorkPageStrapiData: new OurWorkPageFactory().getMockData(),
-  };
-
-  const navigationBarStrapiData = new navigationBarFactory().getMockData();
-  const footerStrapiData = new FooterFactory().getMockData();
+  const mockData = new OurWorkPageFactory().getMockData();
 
   const setup = async () => {
-    (useLoaderData as Mock).mockReturnValue(mockLoaderData);
-    render(
-      <SharedDataContext.Provider
-        value={{
-          navigationBarContent: navigationBarStrapiData,
-          footerContent: footerStrapiData,
-        }}
-      >
-        <MemoryRouter>
-          <OurWorkPage />
-        </MemoryRouter>
-      </SharedDataContext.Provider>
-    );
+    (vi.mocked(useQuery) as Mock).mockReturnValue({
+      data: mockData,
+      isLoading: false,
+      error: null,
+    });
+
+    renderWithProviders(<OurWorkPage />);
   };
 
   beforeEach(() => {

--- a/src/pages/our-work-page/OurWorkPage.tsx
+++ b/src/pages/our-work-page/OurWorkPage.tsx
@@ -1,40 +1,45 @@
 import React from 'react';
 import PageWrapper from '../../components/page-wrapper/PageWrapper';
 import { Col, Container, Row } from 'react-bootstrap';
-import { useLoaderData } from 'react-router-dom';
-import { LoaderData } from '../../data/types/LoaderData';
 import LandingCardDesktop from '../../components/landing-card/desktop/LandingCardDesktop';
 import LandingCardMobile from '../../components/landing-card/mobile/landingCardMobile';
 import OurWorkPageQuoteSection from '../../components/our-work-page/our-work-page-quote-section/OurWorkPageQuoteSection';
 import OurWorkPageAccordion from '../../components/our-work-page/our-work-page-accordion/OurWorkPageAccordion';
 import Metric from '../../components/metric/Metric';
+import { useQuery } from '@tanstack/react-query';
+import { getOurWorkPageStrapiData } from '../../api/strapiApi';
+import Loading from '../../components/loading/Loading';
+import { OurWorkPageStrapiContent } from '../../data/interfaces/our-work-page/OurWorkPageStrapiContent';
 
 const OurWorkPage: React.FC = () => {
-  const { ourWorkPageStrapiData } = useLoaderData() as LoaderData;
+  const { data, isPending, error } = useQuery<OurWorkPageStrapiContent>({
+    queryKey: ['ourWorkPage'],
+    queryFn: getOurWorkPageStrapiData,
+  });
+
+  if (isPending) return <Loading />;
+  if (error || !data) return <p>Error Loading Data</p>;
+
   return (
     <PageWrapper>
       <Row>
         <Col>
           <div className="d-none d-sm-block mb-5">
-            <LandingCardDesktop
-              landingCard={ourWorkPageStrapiData.landingImage}
-            />
+            <LandingCardDesktop landingCard={data.landingImage} />
           </div>
           <div className="d-sm-none">
-            <LandingCardMobile
-              landingCard={ourWorkPageStrapiData.landingImage}
-            />
+            <LandingCardMobile landingCard={data.landingImage} />
           </div>
         </Col>
       </Row>
       <Container className="mb-5">
         <Row className="gx-5 mb-5">
           <Col xl="4">
-            <OurWorkPageQuoteSection quoteData={ourWorkPageStrapiData.quote} />
+            <OurWorkPageQuoteSection quoteData={data.quote} />
           </Col>
           <Col xl={{ span: 7, offset: 1 }} sm="12">
             <Row>
-              {ourWorkPageStrapiData.metrics.map((metric, index) => (
+              {data.metrics.map((metric, index) => (
                 <Col key={index} xl="6" sm="12">
                   <Metric metricData={metric} />
                 </Col>
@@ -48,22 +53,20 @@ const OurWorkPage: React.FC = () => {
               data-testid="our-work-page-accordion-title"
               className="fs-2 fw-bolder text-center"
             >
-              {ourWorkPageStrapiData.accordionSection.title}
+              {data.accordionSection.title}
             </h2>
             <p
               data-testid="our-work-page-accordion-description"
               className="fs-5 text-center"
             >
-              {ourWorkPageStrapiData.accordionSection.description}
+              {data.accordionSection.description}
             </p>
           </Col>
         </Row>
         <Row className="d-flex justify-content-center">
           <Col md="8">
             <OurWorkPageAccordion
-              accordionData={
-                ourWorkPageStrapiData.accordionSection.accordionItems
-              }
+              accordionData={data.accordionSection.accordionItems}
             />
           </Col>
         </Row>

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { createBrowserRouter } from 'react-router-dom';
 import {
-  getAboutUsPageStrapiData,
   getBlogPostsStrapiData,
   getDonatePageStrapiData,
   getGetInvolvedPageStrapiData,
@@ -85,12 +84,6 @@ const createRoutes = async () => {
     {
       path: '/about-us',
       element: <AboutUsPage />,
-      loader: async () => {
-        const aboutUsPageStrapiData = await getAboutUsPageStrapiData();
-        return {
-          aboutUsPageStrapiData,
-        };
-      },
     },
     {
       path: '/get-involved',

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -7,7 +7,6 @@ import {
   getGetInvolvedPageStrapiData,
   getLandingPageStrapiData,
   getOurDonorsPageStrapiData,
-  getOurMissionVisionAndValuesPageStrapiData,
   getOurWorkPageStrapiData,
   getOurWorkSubPagesStrapiData,
 } from './api/strapiApi';
@@ -75,13 +74,6 @@ const createRoutes = async () => {
     {
       path: '/our-mission-vision-and-values',
       element: <OurMissionVisionAndValuesPage />,
-      loader: async () => {
-        const ourMissionVisionAndValuesStrapiData =
-          await getOurMissionVisionAndValuesPageStrapiData();
-        return {
-          ourMissionVisionAndValuesStrapiData,
-        };
-      },
     },
     {
       path: '/our-team',

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -3,7 +3,6 @@ import { createBrowserRouter } from 'react-router-dom';
 import {
   getBlogPostsStrapiData,
   getDonatePageStrapiData,
-  getGetInvolvedPageStrapiData,
   getLandingPageStrapiData,
   getOurWorkPageStrapiData,
   getOurWorkSubPagesStrapiData,
@@ -88,12 +87,6 @@ const createRoutes = async () => {
     {
       path: '/get-involved',
       element: <GetInvolvedPage />,
-      loader: async () => {
-        const getInvolvedPageStrapiData = await getGetInvolvedPageStrapiData();
-        return {
-          getInvolvedPageStrapiData,
-        };
-      },
     },
     {
       path: '/donate',

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -3,7 +3,6 @@ import { createBrowserRouter } from 'react-router-dom';
 import {
   getBlogPostsStrapiData,
   getLandingPageStrapiData,
-  getOurWorkPageStrapiData,
   getOurWorkSubPagesStrapiData,
 } from './api/strapiApi';
 import LandingPage from './pages/landing-page/LandingPage';
@@ -94,12 +93,6 @@ const createRoutes = async () => {
     {
       path: '/our-work',
       element: <OurWorkPage />,
-      loader: async () => {
-        const ourWorkPageStrapiData = await getOurWorkPageStrapiData();
-        return {
-          ourWorkPageStrapiData,
-        };
-      },
     },
     {
       path: '/blog-home',

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -6,7 +6,6 @@ import {
   getDonatePageStrapiData,
   getGetInvolvedPageStrapiData,
   getLandingPageStrapiData,
-  getOurDonorsPageStrapiData,
   getOurWorkPageStrapiData,
   getOurWorkSubPagesStrapiData,
 } from './api/strapiApi';
@@ -82,12 +81,6 @@ const createRoutes = async () => {
     {
       path: '/our-donors',
       element: <OurDonorsPage />,
-      loader: async () => {
-        const ourDonorsPageStrapiData = await getOurDonorsPageStrapiData();
-        return {
-          ourDonorsPageStrapiData,
-        };
-      },
     },
     {
       path: '/about-us',

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { createBrowserRouter } from 'react-router-dom';
 import {
   getBlogPostsStrapiData,
-  getDonatePageStrapiData,
   getLandingPageStrapiData,
   getOurWorkPageStrapiData,
   getOurWorkSubPagesStrapiData,
@@ -91,12 +90,6 @@ const createRoutes = async () => {
     {
       path: '/donate',
       element: <DonatePage />,
-      loader: async () => {
-        const donatePageStrapiData = await getDonatePageStrapiData();
-        return {
-          donatePageStrapiData,
-        };
-      },
     },
     {
       path: '/our-work',

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -96,7 +96,7 @@ const createRoutes = async () => {
     },
     {
       path: '/blog-home',
-      element: <BlogHomePage blogPages={blogPages} />,
+      element: <BlogHomePage />,
     },
     ...dynamicOurWorkSubPageRoutes,
     ...blogPageRoutes,

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -8,7 +8,6 @@ import {
   getLandingPageStrapiData,
   getOurDonorsPageStrapiData,
   getOurMissionVisionAndValuesPageStrapiData,
-  getOurTeamPageStrapiData,
   getOurWorkPageStrapiData,
   getOurWorkSubPagesStrapiData,
 } from './api/strapiApi';
@@ -87,12 +86,6 @@ const createRoutes = async () => {
     {
       path: '/our-team',
       element: <OurTeamPage />,
-      loader: async () => {
-        const ourTeamPageStrapiData = await getOurTeamPageStrapiData();
-        return {
-          ourTeamPageStrapiData,
-        };
-      },
     },
     {
       path: '/our-donors',

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -4,6 +4,14 @@ import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 import { afterAll, afterEach, beforeAll, vi } from 'vitest';
 
+vi.mock('@tanstack/react-query', async () => {
+  const actual = await vi.importActual('@tanstack/react-query');
+  return {
+    ...actual,
+    useQuery: vi.fn(),
+  };
+});
+
 export const AXIOS_MOCK = new MockAdapter(axios);
 
 beforeAll(() => {

--- a/src/test/helpers/helpers.tsx
+++ b/src/test/helpers/helpers.tsx
@@ -1,0 +1,35 @@
+import { QueryClientProvider, QueryClient } from '@tanstack/react-query';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { SharedDataContext } from '../../contexts/SharedDataProvider';
+import FooterFactory from '../factories/strapi/FooterFactory';
+import NavigationBarFactory from '../factories/strapi/NavigationBarFactory';
+import { render } from '@testing-library/react';
+
+export function renderWithProviders(element: React.ReactElement) {
+  const navigationBarStrapiData = new NavigationBarFactory().getMockData();
+  const footerStrapiData = new FooterFactory().getMockData();
+
+  return render(
+    <QueryClientProvider client={createTestQueryClient()}>
+      <SharedDataContext.Provider
+        value={{
+          navigationBarContent: navigationBarStrapiData,
+          footerContent: footerStrapiData,
+        }}
+      >
+        <MemoryRouter>{element}</MemoryRouter>
+      </SharedDataContext.Provider>
+    </QueryClientProvider>
+  );
+}
+
+function createTestQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+}


### PR DESCRIPTION
# Context

- We want to lazy load pages and add some caching in to improve performance on the site. Additionally we want the codebase to follow best React practices. The result is implementing React Query which has caching out the box and will move loading off the routes to make lazy loading easier as well as testing.

## Changes proposed in this PR

- Refactor non-template-pages to use React Query
