### PR TITLE
Implement gift aid

### DIFF
--- a/src/api/paymentApi.tsx
+++ b/src/api/paymentApi.tsx
@@ -3,7 +3,8 @@ import { PaymentType } from '../data/types/PaymentType';
 
 export async function createCheckoutSession(
   amount: number,
-  paymentType: PaymentType
+  paymentType: PaymentType,
+  giftAidDonation: boolean
 ): Promise<string> {
   try {
     const response = await axios.post<{ url: string }>(
@@ -13,6 +14,7 @@ export async function createCheckoutSession(
         amountInPounds: amount,
         cancelUrl: window.location.pathname,
         currency: 'gbp',
+        giftAidDonation: giftAidDonation,
       },
       {
         headers: {

--- a/src/components/donate-page/donate-page-payment-section/DonatePagePaymentSection.tsx
+++ b/src/components/donate-page/donate-page-payment-section/DonatePagePaymentSection.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { PaymentSection } from '../../../data/interfaces/payment/PaymentSection';
-import { Col, Row } from 'react-bootstrap';
+import { Col, Form, Row } from 'react-bootstrap';
 import PaymentTypeToggle from '../../payment/payment-type-toggle/PaymentTypeToggle';
 import PaymentOptionUserValue from '../../payment/payment-options/payment-option-user-value/PaymentOptionUserValue';
 import PaymentOptionStripeValue from '../../payment/payment-options/payment-option-stripe-value/PaymentOptionStripeValue';
@@ -13,6 +13,7 @@ type Props = {
 
 const DonatePagePaymentSection: React.FC<Props> = ({ paymentStrapiData }) => {
   const [paymentType, setPaymentType] = useState<PaymentType>('monthly');
+  const [giftAidDonation, setGiftAidDonation] = useState<boolean>(false);
   return (
     <div
       data-testid="donate-page-payment-section"
@@ -40,11 +41,24 @@ const DonatePagePaymentSection: React.FC<Props> = ({ paymentStrapiData }) => {
           </p>
         </Col>
       </Row>
-      <Row className="mb-5">
+      <Row className="mb-4">
         <Col className="text-center">
           <PaymentTypeToggle
             paymentType={paymentType}
             setPaymentType={setPaymentType}
+          />
+        </Col>
+      </Row>
+      <Row className="mb-4">
+        <Col className="d-flex justify-content-center">
+          <Form.Check
+            type="checkbox"
+            id="gift-aid-checkbox"
+            label="I am a UK taxpayer and I want Dream Renewables to claim Gift Aid on my donation"
+            checked={giftAidDonation}
+            onChange={() => setGiftAidDonation((prev) => !prev)}
+            className={`${styles.giftAidCheckbox} fs-5`}
+            data-testid="gift-aid-checkbox"
           />
         </Col>
       </Row>
@@ -55,6 +69,7 @@ const DonatePagePaymentSection: React.FC<Props> = ({ paymentStrapiData }) => {
               paymentOption={paymentOption}
               paymentOptionIcon={paymentStrapiData.paymentOptionIcon}
               paymentType={paymentType}
+              giftAidDonation={giftAidDonation}
             />
           </Col>
         ))}
@@ -62,6 +77,7 @@ const DonatePagePaymentSection: React.FC<Props> = ({ paymentStrapiData }) => {
           <PaymentOptionUserValue
             paymentOptionIcon={paymentStrapiData.paymentOptionIcon}
             paymentType={paymentType}
+            giftAidDonation={giftAidDonation}
           />
         </Col>
       </Row>

--- a/src/components/donate-page/donate-page-payment-section/DonatePagePaymentSection.tsx
+++ b/src/components/donate-page/donate-page-payment-section/DonatePagePaymentSection.tsx
@@ -3,7 +3,7 @@ import { PaymentSection } from '../../../data/interfaces/payment/PaymentSection'
 import { Col, Form, Row } from 'react-bootstrap';
 import PaymentTypeToggle from '../../payment/payment-type-toggle/PaymentTypeToggle';
 import PaymentOptionUserValue from '../../payment/payment-options/payment-option-user-value/PaymentOptionUserValue';
-import PaymentOptionStripeValue from '../../payment/payment-options/payment-option-stripe-value/PaymentOptionStripeValue';
+import PaymentOptionCmsValue from '../../payment/payment-options/payment-option-cms-value/PaymentOptionCmsValue';
 import styles from './donatePagePaymentSection.module.scss';
 import { PaymentType } from '../../../data/types/PaymentType';
 
@@ -65,7 +65,7 @@ const DonatePagePaymentSection: React.FC<Props> = ({ paymentStrapiData }) => {
       <Row className="d-flex justify-content-center">
         {paymentStrapiData.paymentOptions.map((paymentOption, index) => (
           <Col key={index} xs={12} className="mb-4">
-            <PaymentOptionStripeValue
+            <PaymentOptionCmsValue
               paymentOption={paymentOption}
               paymentOptionIcon={paymentStrapiData.paymentOptionIcon}
               paymentType={paymentType}

--- a/src/components/donate-page/donate-page-payment-section/donatePagePaymentSection.module.scss
+++ b/src/components/donate-page/donate-page-payment-section/donatePagePaymentSection.module.scss
@@ -4,3 +4,18 @@
     border-radius: 25px;
   }
 }
+
+.giftAidCheckbox input[type='checkbox'] {
+  accent-color: unset;
+  border: 1px solid grey;
+
+  &:checked {
+    background-color: var(--primary);
+    border-color: grey;
+    background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3e%3cpath fill='none' stroke='black' stroke-linecap='round' stroke-linejoin='round' stroke-width='3' d='m6 10 3 3 6-6'/%3e%3c/svg%3e");
+  }
+
+  &:focus {
+    box-shadow: none;
+  }
+}

--- a/src/components/donate-page/donate-page-payment-section/donatePagePaymentSection.test.tsx
+++ b/src/components/donate-page/donate-page-payment-section/donatePagePaymentSection.test.tsx
@@ -46,7 +46,7 @@ describe('DonatePagePaymentSection', () => {
     test('should render multiple payment options after data is loaded', async () => {
       await waitFor(() => {
         expect(
-          screen.getAllByTestId('payment-option-stripe-value').length
+          screen.getAllByTestId('payment-option-cms-value').length
         ).toEqual(3);
       });
     });

--- a/src/components/payment/payment-options/payment-option-cms-value/PaymentOptionCmsValue.tsx
+++ b/src/components/payment/payment-options/payment-option-cms-value/PaymentOptionCmsValue.tsx
@@ -17,6 +17,7 @@ const PaymentOptionCmsValue: React.FC<Props> = ({
   paymentOption,
   paymentOptionIcon,
   paymentType,
+  giftAidDonation,
 }) => {
   const [isLoading, setIsLoading] = useState(false);
 
@@ -25,7 +26,8 @@ const PaymentOptionCmsValue: React.FC<Props> = ({
     try {
       const sessionUrl = await createCheckoutSession(
         paymentOption.amount,
-        paymentType
+        paymentType,
+        giftAidDonation
       );
       window.location.href = sessionUrl;
     } catch (err) {

--- a/src/components/payment/payment-options/payment-option-cms-value/PaymentOptionCmsValue.tsx
+++ b/src/components/payment/payment-options/payment-option-cms-value/PaymentOptionCmsValue.tsx
@@ -13,7 +13,7 @@ type Props = {
   giftAidDonation: boolean;
 };
 
-const PaymentOptionStripeValue: React.FC<Props> = ({
+const PaymentOptionCmsValue: React.FC<Props> = ({
   paymentOption,
   paymentOptionIcon,
   paymentType,
@@ -39,15 +39,12 @@ const PaymentOptionStripeValue: React.FC<Props> = ({
       <div
         className={`${styles.paymentOptionWrapper} p-3 d-flex align-items-center justify-content-between`}
       >
-        <p
-          data-testid="payment-option-stripe-value"
-          className="fs-1 fw-bold mb-0"
-        >
+        <p data-testid="payment-option-cms-value" className="fs-1 fw-bold mb-0">
           £{paymentOption.amount}
         </p>
 
         <Button
-          data-testid="payment-option-stripe-button"
+          data-testid="payment-option-cms-button"
           className={styles.paymentButton}
           onClick={clickHandler}
           disabled={isLoading}
@@ -69,7 +66,7 @@ const PaymentOptionStripeValue: React.FC<Props> = ({
         </Button>
       </div>
       <p
-        data-testid="payment-option-stripe-description"
+        data-testid="payment-option-cms-description"
         className="ms-2 mt-3 fs-5"
       >
         {paymentOption.description}
@@ -78,4 +75,4 @@ const PaymentOptionStripeValue: React.FC<Props> = ({
   );
 };
 
-export default PaymentOptionStripeValue;
+export default PaymentOptionCmsValue;

--- a/src/components/payment/payment-options/payment-option-cms-value/paymentOptionCmsValue.test.tsx
+++ b/src/components/payment/payment-options/payment-option-cms-value/paymentOptionCmsValue.test.tsx
@@ -3,17 +3,18 @@ import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import LandingPageFactory from '../../../../test/factories/strapi/LandingPageFactory';
-import PaymentOptionStripeValue from './PaymentOptionStripeValue';
+import PaymentOptionCmsValue from './PaymentOptionCmsValue';
 
-describe('PaymentOptionStripeValue', () => {
+describe('PaymentOptionCmsValue', () => {
   beforeEach(() => {
     const mockData = new LandingPageFactory().getMockData();
     render(
       <MemoryRouter>
-        <PaymentOptionStripeValue
+        <PaymentOptionCmsValue
           paymentOption={mockData.paymentSection.paymentOptions[0]}
           paymentOptionIcon={mockData.paymentSection.paymentOptionIcon}
           paymentType="monthly"
+          giftAidDonation={true}
         />
       </MemoryRouter>
     );
@@ -23,7 +24,7 @@ describe('PaymentOptionStripeValue', () => {
     test('should render passed value after data is loaded', async () => {
       await waitFor(() => {
         expect(
-          screen.getByTestId('payment-option-stripe-value')
+          screen.getByTestId('payment-option-cms-value')
         ).toBeInTheDocument();
       });
     });
@@ -31,7 +32,7 @@ describe('PaymentOptionStripeValue', () => {
     test('should render button after data is loaded', async () => {
       await waitFor(() => {
         expect(
-          screen.getByTestId('payment-option-stripe-button')
+          screen.getByTestId('payment-option-cms-button')
         ).toBeInTheDocument();
       });
     });
@@ -39,7 +40,7 @@ describe('PaymentOptionStripeValue', () => {
     test('should render description after data is loaded', async () => {
       await waitFor(() => {
         expect(
-          screen.getByTestId('payment-option-stripe-description')
+          screen.getByTestId('payment-option-cms-description')
         ).toBeInTheDocument();
       });
     });

--- a/src/components/payment/payment-options/payment-option-stripe-value/PaymentOptionStripeValue.tsx
+++ b/src/components/payment/payment-options/payment-option-stripe-value/PaymentOptionStripeValue.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { PaymentOption } from '../../../../data/interfaces/util/PaymentOption';
 import { ImageStrapiContent } from '../../../../data/interfaces/util/ImageStrapiContent';
-import { Button, Image } from 'react-bootstrap';
+import { Button, Image, Spinner } from 'react-bootstrap';
 import styles from '../paymentOptionUtil.module.scss';
 import { createCheckoutSession } from '../../../../api/paymentApi';
 import { PaymentType } from '../../../../data/types/PaymentType';
@@ -18,12 +18,20 @@ const PaymentOptionStripeValue: React.FC<Props> = ({
   paymentOptionIcon,
   paymentType,
 }) => {
+  const [isLoading, setIsLoading] = useState(false);
+
   const clickHandler = async () => {
-    const sessionUrl = await createCheckoutSession(
-      paymentOption.amount,
-      paymentType
-    );
-    window.location.href = sessionUrl;
+    setIsLoading(true);
+    try {
+      const sessionUrl = await createCheckoutSession(
+        paymentOption.amount,
+        paymentType
+      );
+      window.location.href = sessionUrl;
+    } catch (err) {
+      console.error('Failed to create Stripe session:', err);
+      setIsLoading(false);
+    }
   };
 
   return (
@@ -42,11 +50,22 @@ const PaymentOptionStripeValue: React.FC<Props> = ({
           data-testid="payment-option-stripe-button"
           className={styles.paymentButton}
           onClick={clickHandler}
+          disabled={isLoading}
         >
-          <Image
-            src={paymentOptionIcon.data.attributes.url}
-            alt={paymentOptionIcon.data.attributes.alternativeText}
-          />
+          {isLoading ? (
+            <Spinner
+              animation="border"
+              size="sm"
+              role="status"
+              aria-hidden="true"
+              variant="dark"
+            />
+          ) : (
+            <Image
+              src={paymentOptionIcon.data.attributes.url}
+              alt={paymentOptionIcon.data.attributes.alternativeText}
+            />
+          )}
         </Button>
       </div>
       <p

--- a/src/components/payment/payment-options/payment-option-stripe-value/PaymentOptionStripeValue.tsx
+++ b/src/components/payment/payment-options/payment-option-stripe-value/PaymentOptionStripeValue.tsx
@@ -10,6 +10,7 @@ type Props = {
   paymentOption: PaymentOption;
   paymentOptionIcon: ImageStrapiContent;
   paymentType: PaymentType;
+  giftAidDonation: boolean;
 };
 
 const PaymentOptionStripeValue: React.FC<Props> = ({

--- a/src/components/payment/payment-options/payment-option-user-value/PaymentOptionUserValue.tsx
+++ b/src/components/payment/payment-options/payment-option-user-value/PaymentOptionUserValue.tsx
@@ -14,6 +14,7 @@ type Props = {
 const PaymentOptionUserValue: React.FC<Props> = ({
   paymentOptionIcon,
   paymentType,
+  giftAidDonation,
 }) => {
   const [amount, setAmount] = useState<string>('');
   const [error, setError] = useState<string | null>(null);
@@ -48,7 +49,8 @@ const PaymentOptionUserValue: React.FC<Props> = ({
     try {
       const sessionUrl = await createCheckoutSession(
         formattedAmount,
-        paymentType
+        paymentType,
+        giftAidDonation
       );
       window.location.href = sessionUrl;
     } catch (err) {

--- a/src/components/payment/payment-options/payment-option-user-value/PaymentOptionUserValue.tsx
+++ b/src/components/payment/payment-options/payment-option-user-value/PaymentOptionUserValue.tsx
@@ -8,6 +8,7 @@ import { PaymentType } from '../../../../data/types/PaymentType';
 type Props = {
   paymentOptionIcon: ImageStrapiContent;
   paymentType: PaymentType;
+  giftAidDonation: boolean;
 };
 
 const PaymentOptionUserValue: React.FC<Props> = ({

--- a/src/components/payment/payment-options/payment-option-user-value/PaymentOptionUserValue.tsx
+++ b/src/components/payment/payment-options/payment-option-user-value/PaymentOptionUserValue.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { ImageStrapiContent } from '../../../../data/interfaces/util/ImageStrapiContent';
-import { InputGroup, Form, Button, Image } from 'react-bootstrap';
+import { InputGroup, Form, Button, Image, Spinner } from 'react-bootstrap';
 import styles from '../paymentOptionUtil.module.scss';
 import { createCheckoutSession } from '../../../../api/paymentApi';
 import { PaymentType } from '../../../../data/types/PaymentType';
@@ -87,10 +87,20 @@ const PaymentOptionUserValue: React.FC<Props> = ({
           onClick={clickHandler}
           disabled={isLoading}
         >
-          <Image
-            src={paymentOptionIcon.data.attributes.url}
-            alt={paymentOptionIcon.data.attributes.alternativeText}
-          />
+          {isLoading ? (
+            <Spinner
+              animation="border"
+              size="sm"
+              role="status"
+              aria-hidden="true"
+              variant="dark"
+            />
+          ) : (
+            <Image
+              src={paymentOptionIcon.data.attributes.url}
+              alt={paymentOptionIcon.data.attributes.alternativeText}
+            />
+          )}
         </Button>
       </div>
       <p

--- a/src/components/payment/payment-options/payment-option-user-value/paymentOptionUserValue.test.tsx
+++ b/src/components/payment/payment-options/payment-option-user-value/paymentOptionUserValue.test.tsx
@@ -13,6 +13,7 @@ describe('PaymentOptionUserValue', () => {
         <PaymentOptionUserValue
           paymentOptionIcon={mockData.paymentSection.paymentOptionIcon}
           paymentType="monthly"
+          giftAidDonation={true}
         />
       </MemoryRouter>
     );

--- a/src/components/payment/payment-section/PaymentSection.tsx
+++ b/src/components/payment/payment-section/PaymentSection.tsx
@@ -3,7 +3,7 @@ import PaymentTypeToggle from '../payment-type-toggle/PaymentTypeToggle';
 import PaymentOptionStripeValue from '../payment-options/payment-option-stripe-value/PaymentOptionStripeValue';
 import PaymentOptionUserValue from '../payment-options/payment-option-user-value/PaymentOptionUserValue';
 import { PaymentSection as IPaymentSection } from '../../../data/interfaces/payment/PaymentSection';
-import { Col, Row } from 'react-bootstrap';
+import { Col, Form, Row } from 'react-bootstrap';
 import styles from './paymentSection.module.scss';
 import { PaymentType } from '../../../data/types/PaymentType';
 
@@ -13,6 +13,7 @@ type Props = {
 
 const PaymentSection: React.FC<Props> = ({ paymentData }) => {
   const [paymentType, setPaymentType] = useState<PaymentType>('monthly');
+  const [giftAidDonation, setGiftAidDonation] = useState<boolean>(false);
   return (
     <div data-testid="payment-section" className="p-5 my-5">
       <Row>
@@ -36,11 +37,24 @@ const PaymentSection: React.FC<Props> = ({ paymentData }) => {
           </p>
         </Col>
       </Row>
-      <Row className="mb-5">
+      <Row className="mb-4">
         <Col className="text-center">
           <PaymentTypeToggle
             paymentType={paymentType}
             setPaymentType={setPaymentType}
+          />
+        </Col>
+      </Row>
+      <Row className="mb-4">
+        <Col className="d-flex justify-content-center">
+          <Form.Check
+            type="checkbox"
+            id="gift-aid-checkbox"
+            label="I am a UK taxpayer and I want Dream Renewables to claim Gift Aid on my donation"
+            checked={giftAidDonation}
+            onChange={() => setGiftAidDonation((prev) => !prev)}
+            className={`${styles.giftAidCheckbox} fs-5`}
+            data-testid="gift-aid-checkbox"
           />
         </Col>
       </Row>
@@ -51,6 +65,7 @@ const PaymentSection: React.FC<Props> = ({ paymentData }) => {
               paymentOption={paymentOption}
               paymentOptionIcon={paymentData.paymentOptionIcon}
               paymentType={paymentType}
+              giftAidDonation={giftAidDonation}
             />
           </Col>
         ))}
@@ -58,6 +73,7 @@ const PaymentSection: React.FC<Props> = ({ paymentData }) => {
           <PaymentOptionUserValue
             paymentOptionIcon={paymentData.paymentOptionIcon}
             paymentType={paymentType}
+            giftAidDonation={giftAidDonation}
           />
         </Col>
       </Row>

--- a/src/components/payment/payment-section/PaymentSection.tsx
+++ b/src/components/payment/payment-section/PaymentSection.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import PaymentTypeToggle from '../payment-type-toggle/PaymentTypeToggle';
-import PaymentOptionStripeValue from '../payment-options/payment-option-stripe-value/PaymentOptionStripeValue';
+import PaymentOptionCmsValue from '../payment-options/payment-option-cms-value/PaymentOptionCmsValue';
 import PaymentOptionUserValue from '../payment-options/payment-option-user-value/PaymentOptionUserValue';
 import { PaymentSection as IPaymentSection } from '../../../data/interfaces/payment/PaymentSection';
 import { Col, Form, Row } from 'react-bootstrap';
@@ -61,7 +61,7 @@ const PaymentSection: React.FC<Props> = ({ paymentData }) => {
       <Row className="d-flex justify-content-center">
         {paymentData.paymentOptions.map((paymentOption, index) => (
           <Col key={index} xs={12} sm={6} md={4} lg={2} className="mb-4">
-            <PaymentOptionStripeValue
+            <PaymentOptionCmsValue
               paymentOption={paymentOption}
               paymentOptionIcon={paymentData.paymentOptionIcon}
               paymentType={paymentType}

--- a/src/components/payment/payment-section/paymentSection.module.scss
+++ b/src/components/payment/payment-section/paymentSection.module.scss
@@ -32,3 +32,18 @@
     }
   }
 }
+
+.giftAidCheckbox input[type='checkbox'] {
+  accent-color: unset;
+  border: 1px solid grey;
+
+  &:checked {
+    background-color: var(--primary);
+    border-color: grey;
+    background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3e%3cpath fill='none' stroke='black' stroke-linecap='round' stroke-linejoin='round' stroke-width='3' d='m6 10 3 3 6-6'/%3e%3c/svg%3e");
+  }
+
+  &:focus {
+    box-shadow: none;
+  }
+}

--- a/src/components/payment/payment-section/paymentSection.test.tsx
+++ b/src/components/payment/payment-section/paymentSection.test.tsx
@@ -46,7 +46,7 @@ describe('paymentSection', () => {
     test('should render multiple payment options after data is loaded', async () => {
       await waitFor(() => {
         expect(
-          screen.getAllByTestId('payment-option-stripe-value').length
+          screen.getAllByTestId('payment-option-cms-value').length
         ).toEqual(4);
       });
     });


### PR DESCRIPTION
# Context

- We need to be able to give users the option to select gift aid, this requires setting up a custom form on the frontend to capture this information.

## Changes proposed in this PR

- Create gift aid checkbox
- Rename Payment option stripe value -> payment option cms value
