### PR TITLE
Create our-story-page with a hacky blogpost implementation

### DIFF
--- a/src/api/strapiApi.tsx
+++ b/src/api/strapiApi.tsx
@@ -14,6 +14,7 @@ import { fetchStrapiData } from './util/fetchStrapiData';
 import { BlogPostsTemplatePageStrapiContent } from '../data/interfaces/blog-post-template-page/BlogPostTemplatePagesStrapiContent';
 import { FundraisingEventTemplatePagesStrapiContent } from '../data/interfaces/fundraising-event-template-page/FundraisingEventTemplatePagesStrapiConent';
 import { JobPostsTemplatePageStrapiContent } from '../data/interfaces/job-post-template-page/JobPostTemplatePagesStrapiContent';
+import { BlogPostTemplatePageStrapiContent } from '../data/interfaces/blog-post-template-page/BlogPostTemplatePageStrapiContent';
 
 export async function getNavigationBarStrapiData(): Promise<NavigationBarStrapiContent> {
   const populateQuery = buildStrapiPopulateQuery([
@@ -90,6 +91,19 @@ export async function getAboutUsPageStrapiData(): Promise<AboutUsPageStrapiConte
     'imageButtonSection.imageButtons.image',
   ]);
   return fetchStrapiData('about-us-page', populateQuery);
+}
+
+export async function getOurStoryPageStrapiData(): Promise<BlogPostTemplatePageStrapiContent> {
+  const populateQuery = buildStrapiPopulateQuery([
+    'landingImage',
+    'title',
+    'blogPostSummary',
+    'author',
+    'publishedAt',
+    'blogPostBody',
+  ]);
+
+  return fetchStrapiData(`our-story-page`, populateQuery);
 }
 
 export async function getOurWorkPageStrapiData(): Promise<OurWorkPageStrapiContent> {

--- a/src/pages/blog-post-template-page/BlogPostTemplatePage.tsx
+++ b/src/pages/blog-post-template-page/BlogPostTemplatePage.tsx
@@ -8,9 +8,13 @@ import RecentBlogPosts from '../../components/recent-blog-posts/RecentBlogPosts'
 
 type Props = {
   strapiData: BlogPostTemplatePageStrapiContent;
+  showPreviousPosts?: boolean;
 };
 
-const BlogPostTemplatePage: React.FC<Props> = ({ strapiData }) => {
+const BlogPostTemplatePage: React.FC<Props> = ({
+  strapiData,
+  showPreviousPosts = true,
+}) => {
   return (
     <PageWrapper>
       <Row>
@@ -61,16 +65,18 @@ const BlogPostTemplatePage: React.FC<Props> = ({ strapiData }) => {
           </Col>
         </Row>
       </Container>
-      <Container>
-        <Row>
-          <Col>
-            <h2 className="fs-5 mb-3">Previous Posts</h2>
-          </Col>
-        </Row>
-        <Row data-testid="blog-grid">
-          <RecentBlogPosts currentBlogPageSlug={strapiData.url} />
-        </Row>
-      </Container>
+      {showPreviousPosts && (
+        <Container>
+          <Row>
+            <Col>
+              <h2 className="fs-5 mb-3">Previous Posts</h2>
+            </Col>
+          </Row>
+          <Row data-testid="blog-grid">
+            <RecentBlogPosts currentBlogPageSlug={strapiData.url} />
+          </Row>
+        </Container>
+      )}
     </PageWrapper>
   );
 };

--- a/src/pages/our-story-page/OurStoryPage.tsx
+++ b/src/pages/our-story-page/OurStoryPage.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { getOurStoryPageStrapiData } from '../../api/strapiApi';
+import Loading from '../../components/loading/Loading';
+import BlogPostTemplatePage from '../blog-post-template-page/BlogPostTemplatePage';
+import { BlogPostTemplatePageStrapiContent } from '../../data/interfaces/blog-post-template-page/BlogPostTemplatePageStrapiContent';
+
+const OurStoryPage: React.FC = () => {
+  const { data, isPending, error } =
+    useQuery<BlogPostTemplatePageStrapiContent>({
+      queryKey: [`ourStoryPage`],
+      queryFn: getOurStoryPageStrapiData,
+    });
+
+  if (isPending) return <Loading />;
+  if (error || !data) throw new Error(`Failed to load data: ${error.message}`);
+
+  return <BlogPostTemplatePage strapiData={data} showPreviousPosts={false} />;
+};
+
+export default OurStoryPage;

--- a/src/routesConfig.tsx
+++ b/src/routesConfig.tsx
@@ -7,6 +7,7 @@ import ErrorBoundary from './components/error-boundary/ErrorBoundary';
 import JobPostsHomePage from './pages/job-posts-home-page/JobPostsHomePage';
 import JobPostPage from './pages/job-post-page/JobPostPage';
 import VolunteeringOpportunitiesHomePage from './pages/volunteer-opportunities-home-page/VolunteeringOpportunitiesHomePage';
+import OurStoryPage from './pages/our-story-page/OurStoryPage';
 
 const OurMissionVisionAndValuesPage = lazy(
   () =>
@@ -92,6 +93,16 @@ export const routesConfig = [
       <ErrorBoundary>
         <Suspense fallback={<Loading />}>
           <AboutUsPage />
+        </Suspense>
+      </ErrorBoundary>
+    ),
+  },
+  {
+    path: '/our-story',
+    element: (
+      <ErrorBoundary>
+        <Suspense fallback={<Loading />}>
+          <OurStoryPage />
         </Suspense>
       </ErrorBoundary>
     ),


### PR DESCRIPTION
# Context

- We want to push for a DR go live. As a result we're cutting a few corners. The our story page is just a light version of the blog page so for now matching the naming conventions to the blog post style will enable us to use the frontend template. In the future we should create the blog page as a template in Strapi with a different name for these use cases.

## Changes proposed in this PR

- Create simple our-story-page from a Blog Template
