### PR TITLE
Hackily implement a philanthropy page with blog post template

### DIFF
--- a/src/api/strapiApi.tsx
+++ b/src/api/strapiApi.tsx
@@ -106,6 +106,19 @@ export async function getOurStoryPageStrapiData(): Promise<BlogPostTemplatePageS
   return fetchStrapiData(`our-story-page`, populateQuery);
 }
 
+export async function getPhilanthropyPageStrapiData(): Promise<BlogPostTemplatePageStrapiContent> {
+  const populateQuery = buildStrapiPopulateQuery([
+    'landingImage',
+    'title',
+    'blogPostSummary',
+    'author',
+    'publishedAt',
+    'blogPostBody',
+  ]);
+
+  return fetchStrapiData(`philanthropy-page`, populateQuery);
+}
+
 export async function getOurWorkPageStrapiData(): Promise<OurWorkPageStrapiContent> {
   const populateQuery = buildStrapiPopulateQuery([
     'landingImage.image',

--- a/src/pages/philanthropy-page/PhilanthropyPage.tsx
+++ b/src/pages/philanthropy-page/PhilanthropyPage.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { useQuery } from '@tanstack/react-query';
+import Loading from '../../components/loading/Loading';
+import BlogPostTemplatePage from '../blog-post-template-page/BlogPostTemplatePage';
+import { BlogPostTemplatePageStrapiContent } from '../../data/interfaces/blog-post-template-page/BlogPostTemplatePageStrapiContent';
+import { getPhilanthropyPageStrapiData } from '../../api/strapiApi';
+
+const PhilanthropyPage: React.FC = () => {
+  const { data, isPending, error } =
+    useQuery<BlogPostTemplatePageStrapiContent>({
+      queryKey: [`philanthropyPage`],
+      queryFn: getPhilanthropyPageStrapiData,
+    });
+
+  if (isPending) return <Loading />;
+  if (error || !data) throw new Error(`Failed to load data: ${error.message}`);
+
+  return <BlogPostTemplatePage strapiData={data} showPreviousPosts={false} />;
+};
+
+export default PhilanthropyPage;

--- a/src/routesConfig.tsx
+++ b/src/routesConfig.tsx
@@ -8,6 +8,7 @@ import JobPostsHomePage from './pages/job-posts-home-page/JobPostsHomePage';
 import JobPostPage from './pages/job-post-page/JobPostPage';
 import VolunteeringOpportunitiesHomePage from './pages/volunteer-opportunities-home-page/VolunteeringOpportunitiesHomePage';
 import OurStoryPage from './pages/our-story-page/OurStoryPage';
+import PhilanthropyPage from './pages/philanthropy-page/PhilanthropyPage';
 
 const OurMissionVisionAndValuesPage = lazy(
   () =>
@@ -103,6 +104,16 @@ export const routesConfig = [
       <ErrorBoundary>
         <Suspense fallback={<Loading />}>
           <OurStoryPage />
+        </Suspense>
+      </ErrorBoundary>
+    ),
+  },
+  {
+    path: '/philanthropy',
+    element: (
+      <ErrorBoundary>
+        <Suspense fallback={<Loading />}>
+          <PhilanthropyPage />
         </Suspense>
       </ErrorBoundary>
     ),


### PR DESCRIPTION
# Context

- We want to push for a DR go live. As a result we're cutting a few corners. The our philanthropy page is just a light version of the blog page so for now matching the naming conventions to the blog post style will enable us to use the blog post template. In the future we should create the blog page as a template in Strapi with a different name for these use cases.

## Changes proposed in this PR

- create philanthropy page
