### PR TITLE
added fundraising bridge page with same format as get involved

### DIFF
--- a/cypress/e2e/components/src/components/fundraisingPage.cy.js
+++ b/cypress/e2e/components/src/components/fundraisingPage.cy.js
@@ -1,0 +1,26 @@
+describe('Fundraising Page', () => {
+  beforeEach(() => {
+    cy.intercept('GET', '**/api/fundraising-page*', {
+      fixture: 'fundraisingPageStrapiResponse.json',
+    }).as('getFundraisingPageStrapiData');
+
+    cy.visit('/fundraising');
+
+    cy.wait('@getNavigationBarStrapiData');
+    cy.wait('@getFooterStrapiData');
+    cy.wait('@getFundraisingPageStrapiData');
+  });
+
+  it('should load the get involved page and verify all elements are present and functioning', () => {
+    cy.get('[data-testid="navbar"]').should('be.visible');
+
+    cy.get('[data-testid="landing-card-desktop"]').should('be.visible');
+    cy.get('[data-testid="get-involved-page-section-title"]').should(
+      'have.length',
+      4
+    );
+    cy.get('[data-testid="payment-section"]').should('be.visible');
+
+    cy.get('[data-testid="footer"]').should('be.visible');
+  });
+});

--- a/fixtures/fundraisingPageStrapiResponse.json
+++ b/fixtures/fundraisingPageStrapiResponse.json
@@ -1,0 +1,310 @@
+{
+  "data": {
+    "id": 1,
+    "attributes": {
+      "landingCard": {
+        "id": 1,
+        "title": "Get Involved",
+        "image": {
+          "data": {
+            "id": 39,
+            "attributes": {
+              "name": "get-involved-landing-image.svg",
+              "alternativeText": "A man measuring something",
+              "caption": "A man measuring something",
+              "width": 1344,
+              "height": 450,
+              "formats": null,
+              "hash": "get_involved_landing_image_8d9ce230de",
+              "ext": ".svg",
+              "mime": "image/svg+xml",
+              "size": 1030.17,
+              "url": "https://strapi-dr-s3-media-bucket.s3",
+              "previewUrl": null,
+              "provider": "aws-s3",
+              "provider_metadata": null,
+              "createdAt": "2025-01-09T07:59:13.313Z",
+              "updatedAt": "2025-01-09T07:59:31.508Z",
+              "isUrlSigned": true
+            }
+          }
+        }
+      },
+      "sections": [
+        {
+          "id": 1,
+          "title": "Fundraising for the future",
+          "description": "Get involved by fundraising for Dream Renewables – whether it’s a bake sale, collection pot or something out of the ordinary – you can help us in our mission to transform the lives of the world’s poorest people and tackle climate change",
+          "linkIcon": {
+            "data": {
+              "id": 12,
+              "attributes": {
+                "name": "arrow-icon.svg",
+                "alternativeText": "arrow icon",
+                "caption": "arrow icon",
+                "width": 8,
+                "height": 9,
+                "formats": null,
+                "hash": "arrow_icon_353b7d5895",
+                "ext": ".svg",
+                "mime": "image/svg+xml",
+                "size": 0.21,
+                "url": "https://strapi-dr-s3-media-bucket.s3",
+                "previewUrl": null,
+                "provider": "aws-s3",
+                "provider_metadata": null,
+                "createdAt": "2024-10-17T21:33:59.252Z",
+                "updatedAt": "2025-01-09T08:05:25.138Z",
+                "isUrlSigned": true
+              }
+            }
+          },
+          "link": {
+            "id": 27,
+            "linkString": "Explore Fundraising",
+            "linkSlug": "about-us"
+          },
+          "image": {
+            "data": {
+              "id": 40,
+              "attributes": {
+                "name": "get-involved-section-image-1.svg",
+                "alternativeText": "people running",
+                "caption": "people running",
+                "width": 406,
+                "height": 381,
+                "formats": null,
+                "hash": "get_involved_section_image_1_aa55be59df",
+                "ext": ".svg",
+                "mime": "image/svg+xml",
+                "size": 5461.89,
+                "url": "https://strapi-dr-s3-media-bucket.s3",
+                "previewUrl": null,
+                "provider": "aws-s3",
+                "provider_metadata": null,
+                "createdAt": "2025-01-09T08:00:00.047Z",
+                "updatedAt": "2025-01-09T08:00:09.467Z",
+                "isUrlSigned": true
+              }
+            }
+          }
+        },
+        {
+          "id": 2,
+          "title": "Offer your help by Volunteering",
+          "description": "Get involved by volunteering with Dream Renewables – whether it’s teaching a workshop, assisting with community projects, or lending your unique skills – you can help us in our mission to transform the lives of Ghana's communities and tackle climate change.",
+          "linkIcon": {
+            "data": {
+              "id": 12,
+              "attributes": {
+                "name": "arrow-icon.svg",
+                "alternativeText": "arrow icon",
+                "caption": "arrow icon",
+                "width": 8,
+                "height": 9,
+                "formats": null,
+                "hash": "arrow_icon_353b7d5895",
+                "ext": ".svg",
+                "mime": "image/svg+xml",
+                "size": 0.21,
+                "url": "https://strapi-dr-s3-media-bucket.s3",
+                "previewUrl": null,
+                "provider": "aws-s3",
+                "provider_metadata": null,
+                "createdAt": "2024-10-17T21:33:59.252Z",
+                "updatedAt": "2025-01-09T08:05:25.138Z",
+                "isUrlSigned": true
+              }
+            }
+          },
+          "link": {
+            "id": 28,
+            "linkString": "Explore Volunteering",
+            "linkSlug": "about-us"
+          },
+          "image": {
+            "data": {
+              "id": 11,
+              "attributes": {
+                "name": "speciality-carousel-image-two.svg",
+                "alternativeText": "People designing a blueprint",
+                "caption": "People designing a blueprint",
+                "width": 536,
+                "height": 536,
+                "formats": null,
+                "hash": "speciality_carousel_image_two_6fec238cfc",
+                "ext": ".svg",
+                "mime": "image/svg+xml",
+                "size": 534.34,
+                "url": "https://strapi-dr-s3-media-bucket.s3",
+                "previewUrl": null,
+                "provider": "aws-s3",
+                "provider_metadata": null,
+                "createdAt": "2024-10-17T18:33:57.593Z",
+                "updatedAt": "2025-01-09T08:02:00.270Z",
+                "isUrlSigned": true
+              }
+            }
+          }
+        },
+        {
+          "id": 3,
+          "title": "Work with us to power the future",
+          "description": "Work with us to empower Ghana's communities through solar energy education. Your skills can help transform lives and combat climate change. Be a part of our mission for a brighter future.",
+          "linkIcon": {
+            "data": {
+              "id": 12,
+              "attributes": {
+                "name": "arrow-icon.svg",
+                "alternativeText": "arrow icon",
+                "caption": "arrow icon",
+                "width": 8,
+                "height": 9,
+                "formats": null,
+                "hash": "arrow_icon_353b7d5895",
+                "ext": ".svg",
+                "mime": "image/svg+xml",
+                "size": 0.21,
+                "url": "https://strapi-dr-s3-media-bucket.s3",
+                "previewUrl": null,
+                "provider": "aws-s3",
+                "provider_metadata": null,
+                "createdAt": "2024-10-17T21:33:59.252Z",
+                "updatedAt": "2025-01-09T08:05:25.138Z",
+                "isUrlSigned": true
+              }
+            }
+          },
+          "link": {
+            "id": 29,
+            "linkString": "Work With Us",
+            "linkSlug": "about-us"
+          },
+          "image": {
+            "data": {
+              "id": 37,
+              "attributes": {
+                "name": "impact-donate-image.svg",
+                "alternativeText": "People shaking hands and laughing",
+                "caption": "People shaking hands and laughing",
+                "width": 406,
+                "height": 284,
+                "formats": null,
+                "hash": "impact_donate_image_044f8940bd",
+                "ext": ".svg",
+                "mime": "image/svg+xml",
+                "size": 2214.91,
+                "url": "https://strapi-dr-s3-media-bucket.s3.eu-west-2",
+                "previewUrl": null,
+                "provider": "aws-s3",
+                "provider_metadata": null,
+                "createdAt": "2025-01-06T23:39:19.743Z",
+                "updatedAt": "2025-01-09T08:02:39.551Z",
+                "isUrlSigned": true
+              }
+            }
+          }
+        },
+        {
+          "id": 4,
+          "title": "Dream big via philantropy",
+          "description": "Your philanthropic efforts can empower Ghana's communities through solar energy education. Help us transform lives and combat climate change. Join our mission for a brighter, sustainable future.",
+          "linkIcon": {
+            "data": {
+              "id": 12,
+              "attributes": {
+                "name": "arrow-icon.svg",
+                "alternativeText": "arrow icon",
+                "caption": "arrow icon",
+                "width": 8,
+                "height": 9,
+                "formats": null,
+                "hash": "arrow_icon_353b7d5895",
+                "ext": ".svg",
+                "mime": "image/svg+xml",
+                "size": 0.21,
+                "url": "https://strapi-dr-s3-media-bucket.s3",
+                "previewUrl": null,
+                "provider": "aws-s3",
+                "provider_metadata": null,
+                "createdAt": "2024-10-17T21:33:59.252Z",
+                "updatedAt": "2025-01-09T08:05:25.138Z",
+                "isUrlSigned": true
+              }
+            }
+          },
+          "link": {
+            "id": 30,
+            "linkString": "Explore Philantropy",
+            "linkSlug": "about-us"
+          },
+          "image": {
+            "data": {
+              "id": 10,
+              "attributes": {
+                "name": "specialty-carousel-image-one.svg",
+                "alternativeText": "People fitting solar panels",
+                "caption": "People fitting solar panels",
+                "width": 508,
+                "height": 537,
+                "formats": null,
+                "hash": "specialty_carousel_image_one_251c066a92",
+                "ext": ".svg",
+                "mime": "image/svg+xml",
+                "size": 1531.63,
+                "url": "https://strapi-dr-s3-media-bucket.s3",
+                "previewUrl": null,
+                "provider": "aws-s3",
+                "provider_metadata": null,
+                "createdAt": "2024-10-17T18:32:49.917Z",
+                "updatedAt": "2025-01-09T08:03:49.336Z",
+                "isUrlSigned": true
+              }
+            }
+          }
+        }
+      ],
+      "paymentSection": {
+        "id": 1,
+        "title": "Directly Impact",
+        "subTitle": "All our donations will help contribute to our amazing work.",
+        "paymentOptionIcon": {
+          "data": {
+            "id": 13,
+            "attributes": {
+              "name": "payment-option-icon.svg",
+              "alternativeText": "arrow icon",
+              "caption": "arrow icon",
+              "width": 40,
+              "height": 41,
+              "formats": null,
+              "hash": "payment_option_icon_daa403f224",
+              "ext": ".svg",
+              "mime": "image/svg+xml",
+              "size": 0.3,
+              "url": "https://strapi-dr-s3-media-bucket.s3",
+              "previewUrl": null,
+              "provider": "aws-s3",
+              "provider_metadata": null,
+              "createdAt": "2024-10-18T08:44:45.356Z",
+              "updatedAt": "2025-01-09T08:05:21.102Z",
+              "isUrlSigned": true
+            }
+          }
+        },
+        "paymentOptions": [
+          {
+            "id": 5,
+            "amount": 5,
+            "description": "Enough to fund workshop supplies for multiple students"
+          },
+          {
+            "id": 6,
+            "amount": 10,
+            "description": "Help aid in developing training programmes to better suit student needs"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/api/strapiApi.tsx
+++ b/src/api/strapiApi.tsx
@@ -15,6 +15,7 @@ import { BlogPostsTemplatePageStrapiContent } from '../data/interfaces/blog-post
 import { FundraisingEventTemplatePagesStrapiContent } from '../data/interfaces/fundraising-event-template-page/FundraisingEventTemplatePagesStrapiConent';
 import { JobPostsTemplatePageStrapiContent } from '../data/interfaces/job-post-template-page/JobPostTemplatePagesStrapiContent';
 import { BlogPostTemplatePageStrapiContent } from '../data/interfaces/blog-post-template-page/BlogPostTemplatePageStrapiContent';
+import { FundraisingPageStrapiContent } from '../data/interfaces/fundraising-page/FundraisingPageStrapiContent';
 
 export async function getNavigationBarStrapiData(): Promise<NavigationBarStrapiContent> {
   const populateQuery = buildStrapiPopulateQuery([
@@ -140,6 +141,18 @@ export async function getGetInvolvedPageStrapiData(): Promise<GetInvolvedPageStr
     'paymentSection.paymentOptionIcon',
   ]);
   return fetchStrapiData('get-involved-page', populateQuery);
+}
+
+export async function getFundraisingPageStrapiData(): Promise<FundraisingPageStrapiContent> {
+  const populateQuery = buildStrapiPopulateQuery([
+    'landingCard.image',
+    'sections.image',
+    'sections.link',
+    'sections.linkIcon',
+    'paymentSection.paymentOptions',
+    'paymentSection.paymentOptionIcon',
+  ]);
+  return fetchStrapiData('fundraising-page', populateQuery);
 }
 
 export async function getDonatePageStrapiData(): Promise<DonatePageStrapiContent> {

--- a/src/data/interfaces/fundraising-page/FundraisingPageStrapiContent.ts
+++ b/src/data/interfaces/fundraising-page/FundraisingPageStrapiContent.ts
@@ -1,0 +1,18 @@
+import { LandingCard } from '../landing-card/LandingCard';
+import { PaymentSection } from '../payment/PaymentSection';
+import { ImageStrapiContent } from '../util/ImageStrapiContent';
+import { StandardLink } from '../util/StandardLink';
+
+export interface FundraisingPageStrapiContent {
+  landingCard: LandingCard;
+  sections: Array<Section>;
+  paymentSection: PaymentSection;
+}
+
+export interface Section {
+  title: string;
+  description: string;
+  image: ImageStrapiContent;
+  link: StandardLink;
+  linkIcon: ImageStrapiContent;
+}

--- a/src/pages/fundraising-page/FundraisingPage.tsx
+++ b/src/pages/fundraising-page/FundraisingPage.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { Col, Row } from 'react-bootstrap';
+import PageWrapper from '../../components/page-wrapper/PageWrapper';
+import LandingCardDesktop from '../../components/landing-card/desktop/LandingCardDesktop';
+import LandingCardMobile from '../../components/landing-card/mobile/landingCardMobile';
+import GetInvolvedPageSection from '../../components/get-involved-page/get-involved-page-section/GetInvolvedPageSection';
+import PaymentSection from '../../components/payment/payment-section/PaymentSection';
+import { useQuery } from '@tanstack/react-query';
+import Loading from '../../components/loading/Loading';
+import { FundraisingPageStrapiContent } from '../../data/interfaces/fundraising-page/FundraisingPageStrapiContent';
+import { getFundraisingPageStrapiData } from '../../api/strapiApi';
+
+const FundraisingPage: React.FC = () => {
+  const { data, isPending, error } = useQuery<FundraisingPageStrapiContent>({
+    queryKey: ['fundraisingPage'],
+    queryFn: getFundraisingPageStrapiData,
+  });
+
+  if (isPending) return <Loading />;
+  if (error || !data) throw new Error(`Failed to load data: ${error.message}`);
+
+  console.log(data);
+
+  return (
+    <PageWrapper>
+      <Row>
+        <Col>
+          <div className="d-none d-sm-block mb-5">
+            <LandingCardDesktop landingCard={data.landingCard} />
+          </div>
+          <div className="d-sm-none mb-5">
+            <LandingCardMobile landingCard={data.landingCard} />
+          </div>
+        </Col>
+      </Row>
+      {data.sections.map((section, index) => (
+        <Row key={index} className="mb-5">
+          <Col>
+            <GetInvolvedPageSection sectionData={section} rowIndex={index} />
+          </Col>
+        </Row>
+      ))}
+      <Row>
+        <Col>
+          <PaymentSection paymentData={data.paymentSection} />
+        </Col>
+      </Row>
+    </PageWrapper>
+  );
+};
+
+export default FundraisingPage;

--- a/src/pages/fundraising-page/fundraisingPage.test.tsx
+++ b/src/pages/fundraising-page/fundraisingPage.test.tsx
@@ -1,0 +1,62 @@
+import { screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  Mock,
+  test,
+  vi,
+} from 'vitest';
+import FundraisingPage from './FundraisingPage';
+import { useQuery } from '@tanstack/react-query';
+import { renderWithProviders } from '../../test/helpers/helpers';
+import FundraisingPageFactory from '../../test/factories/strapi/FundraisingPageFactory';
+
+describe('FundraisingPage', () => {
+  const mockData = new FundraisingPageFactory().getMockData();
+
+  const setup = async () => {
+    (vi.mocked(useQuery) as Mock).mockReturnValue({
+      data: mockData,
+      isLoading: false,
+      error: null,
+    });
+
+    renderWithProviders(<FundraisingPage />);
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('render elements', () => {
+    test('should render the get involved landing card when data is loaded', async () => {
+      await setup();
+      await waitFor(() => {
+        expect(screen.getByTestId('landing-card-desktop')).toBeInTheDocument();
+      });
+    });
+
+    test('should render the get involved page sections when data is loaded', async () => {
+      await setup();
+      await waitFor(() => {
+        expect(
+          screen.getAllByTestId('get-involved-page-section-title').length
+        ).toBe(4);
+      });
+    });
+
+    test('should render payment section', async () => {
+      await setup();
+      await waitFor(() => {
+        expect(screen.getByTestId('payment-section')).toBeInTheDocument();
+      });
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+});

--- a/src/routesConfig.tsx
+++ b/src/routesConfig.tsx
@@ -9,6 +9,7 @@ import JobPostPage from './pages/job-post-page/JobPostPage';
 import VolunteeringOpportunitiesHomePage from './pages/volunteer-opportunities-home-page/VolunteeringOpportunitiesHomePage';
 import OurStoryPage from './pages/our-story-page/OurStoryPage';
 import PhilanthropyPage from './pages/philanthropy-page/PhilanthropyPage';
+import FundraisingPage from './pages/fundraising-page/FundraisingPage';
 
 const OurMissionVisionAndValuesPage = lazy(
   () =>
@@ -124,6 +125,16 @@ export const routesConfig = [
       <ErrorBoundary>
         <Suspense fallback={<Loading />}>
           <GetInvolvedPage />
+        </Suspense>
+      </ErrorBoundary>
+    ),
+  },
+  {
+    path: '/fundraising',
+    element: (
+      <ErrorBoundary>
+        <Suspense fallback={<Loading />}>
+          <FundraisingPage />
         </Suspense>
       </ErrorBoundary>
     ),

--- a/src/test/factories/strapi/FundraisingPageFactory.ts
+++ b/src/test/factories/strapi/FundraisingPageFactory.ts
@@ -1,0 +1,15 @@
+import fundraisingPageStrapiResponse from '../../../../fixtures/fundraisingPageStrapiResponse.json';
+import { FundraisingPageStrapiContent } from '../../../data/interfaces/fundraising-page/FundraisingPageStrapiContent';
+
+import BaseFactory from '../BaseFactory';
+
+class FundraisingPageFactory extends BaseFactory<FundraisingPageStrapiContent> {
+  constructor() {
+    super(
+      fundraisingPageStrapiResponse,
+      `${import.meta.env.VITE_BASE_URL}/api/fundraising-page?populate[0]=landingCard.image&populate[1]=sections.image&populate[2]=sections.link&populate[3]=sections.linkIcon&populate[4]=paymentSection.paymentOptions&populate[5]=paymentSection.paymentOptionIcon`
+    );
+  }
+}
+
+export default FundraisingPageFactory;


### PR DESCRIPTION
# Context

- Users need a way to easily navigate between the various different fundraising avenues

## Changes proposed in this PR

- Added a fundraising page intended to be pointed too from the get involved page
