### PR TITLE
annual report page added with all tests passing

### DIFF
--- a/cypress/e2e/components/src/components/AnnualReportsPage.cy.js
+++ b/cypress/e2e/components/src/components/AnnualReportsPage.cy.js
@@ -1,0 +1,50 @@
+describe('Annual Reports Page', () => {
+  beforeEach(() => {
+    cy.intercept('GET', '**/api/annual-reports*', {
+      fixture: 'annualReportsStrapiResponse.json',
+    }).as('getAnnualReportsPageStrapiData');
+
+    cy.visit('/annual-reports');
+
+    cy.wait('@getNavigationBarStrapiData');
+    cy.wait('@getFooterStrapiData');
+    cy.wait('@getAnnualReportsPageStrapiData');
+  });
+
+  it('should load the header and footer and verify all elements are present and functioning', () => {
+    cy.get('[data-testid="navbar"]').should('be.visible');
+    cy.get('[data-testid="footer"]').should('be.visible');
+  });
+
+  it('should load the Annual Reports Page and display the title', () => {
+    cy.get('[data-testid="annual-reports-home-page-title"]')
+      .should('be.visible')
+      .and('contain.text', 'Annual Reports');
+  });
+
+  it('should display a grid of annual report cards', () => {
+    cy.get('[data-testid="annual-reports-grid"]')
+      .should('be.visible')
+      .find('[data-testid="annual-report-card"]')
+      .should('have.length.greaterThan', 0);
+  });
+
+  it('should ensure each annual report card has necessary elements', () => {
+    cy.get('[data-testid="annual-report-card"]').each((card) => {
+      cy.wrap(card).within(() => {
+        cy.get('[data-testid^="annual-report-card-image-"]').should(
+          'be.visible'
+        );
+        cy.get('[data-testid^="annual-report-card-title-"]').should(
+          'be.visible'
+        );
+        cy.get('[data-testid^="annual-report-card-description-"]').should(
+          'be.visible'
+        );
+        cy.get('[data-testid^="annual-report-card-date-"]').should(
+          'be.visible'
+        );
+      });
+    });
+  });
+});

--- a/fixtures/annualReportsStrapiResponse.json
+++ b/fixtures/annualReportsStrapiResponse.json
@@ -1,0 +1,120 @@
+{
+  "data": [
+    {
+      "id": 3,
+      "attributes": {
+        "title": "annual report 2",
+        "description": "the first one lorem ipsum the first one lorem ipsum the first one lorem ipsum the first one lorem ipsum",
+        "link": "https://www.google.co.uk/",
+        "datePublished": "2026-01-01",
+        "createdAt": "2025-06-01T12:54:24.563Z",
+        "updatedAt": "2025-06-01T13:21:12.815Z",
+        "publishedAt": "2025-06-01T13:21:12.813Z",
+        "cardImage": {
+          "data": {
+            "id": 48,
+            "attributes": {
+              "name": "get-involved-landing-image.svg",
+              "alternativeText": "get-involved-landing-image.svg",
+              "caption": "get-involved-landing-image.svg",
+              "width": 1344,
+              "height": 450,
+              "formats": null,
+              "hash": "get_involved_landing_image_ecb93f0f7e",
+              "ext": ".svg",
+              "mime": "image/svg+xml",
+              "size": 1030.17,
+              "url": "https://strapi-dr-s3-media-bucket.s3",
+              "previewUrl": null,
+              "provider": "aws-s3",
+              "provider_metadata": null,
+              "createdAt": "2025-01-19T19:09:15.280Z",
+              "updatedAt": "2025-01-19T19:09:15.280Z",
+              "isUrlSigned": true
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": 1,
+      "attributes": {
+        "title": "annual report 1",
+        "description": "the first one lorem ipsum the first one lorem ipsum the first one lorem ipsum the first one lorem ipsum",
+        "link": "https://www.google.co.uk/",
+        "datePublished": "2025-01-01",
+        "createdAt": "2025-06-01T12:54:24.563Z",
+        "updatedAt": "2025-06-01T13:20:16.357Z",
+        "publishedAt": "2025-06-01T13:20:16.354Z",
+        "cardImage": {
+          "data": {
+            "id": 48,
+            "attributes": {
+              "name": "get-involved-landing-image.svg",
+              "alternativeText": "get-involved-landing-image.svg",
+              "caption": "get-involved-landing-image.svg",
+              "width": 1344,
+              "height": 450,
+              "formats": null,
+              "hash": "get_involved_landing_image_ecb93f0f7e",
+              "ext": ".svg",
+              "mime": "image/svg+xml",
+              "size": 1030.17,
+              "url": "https://strapi-dr-s3-media-bucket.s3",
+              "previewUrl": null,
+              "provider": "aws-s3",
+              "provider_metadata": null,
+              "createdAt": "2025-01-19T19:09:15.280Z",
+              "updatedAt": "2025-01-19T19:09:15.280Z",
+              "isUrlSigned": true
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": 2,
+      "attributes": {
+        "title": "annual report 0",
+        "description": "the first one lorem ipsum the first one lorem ipsum the first one lorem ipsum the first one lorem ipsum",
+        "link": "https://www.google.co.uk/",
+        "datePublished": "2024-01-01",
+        "createdAt": "2025-06-01T12:54:24.563Z",
+        "updatedAt": "2025-06-01T13:20:58.293Z",
+        "publishedAt": "2025-06-01T13:20:58.292Z",
+        "cardImage": {
+          "data": {
+            "id": 48,
+            "attributes": {
+              "name": "get-involved-landing-image.svg",
+              "alternativeText": "get-involved-landing-image.svg",
+              "caption": "get-involved-landing-image.svg",
+              "width": 1344,
+              "height": 450,
+              "formats": null,
+              "hash": "get_involved_landing_image_ecb93f0f7e",
+              "ext": ".svg",
+              "mime": "image/svg+xml",
+              "size": 1030.17,
+              "url": "https://strapi-dr-s3-media-bucket.s3",
+              "previewUrl": null,
+              "provider": "aws-s3",
+              "provider_metadata": null,
+              "createdAt": "2025-01-19T19:09:15.280Z",
+              "updatedAt": "2025-01-19T19:09:15.280Z",
+              "isUrlSigned": true
+            }
+          }
+        }
+      }
+    }
+  ],
+  "meta": {
+    "pagination": {
+      "page": 1,
+      "pageSize": 25,
+      "pageCount": 1,
+      "total": 3
+    }
+  }
+}

--- a/src/api/strapiApi.tsx
+++ b/src/api/strapiApi.tsx
@@ -15,6 +15,7 @@ import { BlogPostsTemplatePageStrapiContent } from '../data/interfaces/blog-post
 import { FundraisingEventTemplatePagesStrapiContent } from '../data/interfaces/fundraising-event-template-page/FundraisingEventTemplatePagesStrapiConent';
 import { JobPostsTemplatePageStrapiContent } from '../data/interfaces/job-post-template-page/JobPostTemplatePagesStrapiContent';
 import { BlogPostTemplatePageStrapiContent } from '../data/interfaces/blog-post-template-page/BlogPostTemplatePageStrapiContent';
+import { AnnualReportsPageStrapiContent } from '../data/interfaces/annual-reports-page/AnnualReportsPageStrapiContent';
 
 export async function getNavigationBarStrapiData(): Promise<NavigationBarStrapiContent> {
   const populateQuery = buildStrapiPopulateQuery([
@@ -321,4 +322,17 @@ export async function getJobPostStrapiData(
   const filter = `filters[url][$eq]=${slug}`;
 
   return fetchStrapiData('job-posts', populateQuery, true, filter);
+}
+
+export async function getAnnualReportsPageStrapiData(): Promise<AnnualReportsPageStrapiContent> {
+  const populateQuery = buildStrapiPopulateQuery([
+    'cardImage',
+    'title',
+    'description',
+    'link',
+    'datePublished',
+  ]);
+  const filter = `sort[0]=datePublished:desc`;
+
+  return await fetchStrapiData(`annual-reports`, populateQuery, true, filter);
 }

--- a/src/components/annual-report-card/AnnualReportCard.tsx
+++ b/src/components/annual-report-card/AnnualReportCard.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { Col, Row, Image, Container } from 'react-bootstrap';
+import styles from './annualReportCard.module.scss';
+import { AnnualReportStrapiContent } from '../../data/interfaces/annual-reports-page/AnnualReportStrapiContent';
+
+type Props = {
+  reportData: AnnualReportStrapiContent;
+};
+
+const AnnualReportCard: React.FC<Props> = ({ reportData }) => {
+  const handleLinkClick = () => {
+    window.scrollTo({ top: 0 });
+  };
+
+  return (
+    <div data-testid="annual-report-card" className="h-100">
+      <Link
+        to={reportData.link}
+        className="rounded-3 text-decoration-none h-100"
+        data-testid={`annual-report-card-link-${reportData.title}`}
+        onClick={handleLinkClick}
+      >
+        <div className="d-flex flex-column rounded-3 h-100 p-3 shadow text-dark">
+          <Row>
+            <Col>
+              <div className="mb-3 d-flex justify-content-center">
+                <Image
+                  fluid
+                  data-testid={`annual-report-card-image-${reportData.title}`}
+                  src={reportData.cardImage.data.attributes.url}
+                  className={`${styles.annualReportCardImage} d-flex object-fit-cover rounded-3`}
+                />
+              </div>
+            </Col>
+          </Row>
+          <Container className="d-flex flex-column flex-grow-1">
+            <Row className="mb-1">
+              <Col>
+                <h1
+                  data-testid={`annual-report-card-title-${reportData.title}`}
+                  className="fs-2 fw-bold mb-1"
+                >
+                  {reportData.title}
+                </h1>
+                <p
+                  data-testid={`annual-report-card-description-${reportData.title}`}
+                  className="fs-6 mb-1"
+                >
+                  {reportData.description}
+                </p>
+              </Col>
+            </Row>
+            <Row className="mt-auto">
+              <Col className="col-auto">
+                <span
+                  data-testid={`annual-report-card-date-${reportData.title}`}
+                  className="text-muted"
+                >
+                  {reportData.datePublished}
+                </span>
+              </Col>
+            </Row>
+          </Container>
+        </div>
+      </Link>
+    </div>
+  );
+};
+
+export default AnnualReportCard;

--- a/src/components/annual-report-card/annualReportCard.module.scss
+++ b/src/components/annual-report-card/annualReportCard.module.scss
@@ -1,0 +1,3 @@
+.annualReportCardImage {
+  height: 150px;
+}

--- a/src/components/annual-report-card/annualReportCard.test.tsx
+++ b/src/components/annual-report-card/annualReportCard.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, test, expect } from 'vitest';
+import AnnualReportCard from './AnnualReportCard';
+import AnnualReportsFactory from '../../test/factories/strapi/AnnualReportsFactory';
+
+const annualReportFactory = new AnnualReportsFactory();
+const mockReportData = annualReportFactory.getMockResponse().data[0].attributes;
+
+describe('AnnualReportCard', () => {
+  const setup = () => {
+    render(
+      <MemoryRouter>
+        <AnnualReportCard reportData={mockReportData} />
+      </MemoryRouter>
+    );
+  };
+
+  describe('Rendering and Content', () => {
+    test('should render the card container', async () => {
+      setup();
+      await waitFor(() => {
+        expect(screen.getByTestId('annual-report-card')).toBeInTheDocument();
+      });
+    });
+
+    test('should render the report title', async () => {
+      setup();
+      await waitFor(() => {
+        expect(
+          screen.getByTestId(`annual-report-card-title-${mockReportData.title}`)
+        ).toHaveTextContent(mockReportData.title);
+      });
+    });
+
+    test('should render the report date', async () => {
+      setup();
+      await waitFor(() => {
+        expect(
+          screen.getByTestId(`annual-report-card-date-${mockReportData.title}`)
+        ).toHaveTextContent(mockReportData.datePublished);
+      });
+    });
+
+    test('should render the card image with the correct src', async () => {
+      setup();
+      await waitFor(() => {
+        expect(
+          screen.getByTestId(`annual-report-card-image-${mockReportData.title}`)
+        ).toHaveAttribute('src', mockReportData.cardImage.data.attributes.url);
+      });
+    });
+  });
+
+  describe('Linking and Navigation', () => {
+    test('should link to the correct annual report URL', async () => {
+      setup();
+      const linkElement = screen.getByTestId(
+        `annual-report-card-link-${mockReportData.title}`
+      ) as HTMLAnchorElement;
+      expect(linkElement).toHaveAttribute('href', mockReportData.link);
+    });
+  });
+});

--- a/src/data/interfaces/annual-reports-page/AnnualReportStrapiContent.ts
+++ b/src/data/interfaces/annual-reports-page/AnnualReportStrapiContent.ts
@@ -1,0 +1,9 @@
+import { ImageStrapiContent } from '../util/ImageStrapiContent';
+
+export interface AnnualReportStrapiContent {
+  title: string;
+  datePublished: string;
+  description: string;
+  cardImage: ImageStrapiContent;
+  link: string;
+}

--- a/src/data/interfaces/annual-reports-page/AnnualReportsPageStrapiContent.ts
+++ b/src/data/interfaces/annual-reports-page/AnnualReportsPageStrapiContent.ts
@@ -1,0 +1,7 @@
+import { AnnualReportStrapiContent } from './AnnualReportStrapiContent';
+
+export interface AnnualReportsPageStrapiContent {
+  data: Array<{
+    attributes: AnnualReportStrapiContent;
+  }>;
+}

--- a/src/pages/annual-reports-page/AnnualReportsPage.tsx
+++ b/src/pages/annual-reports-page/AnnualReportsPage.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import PageWrapper from '../../components/page-wrapper/PageWrapper';
+import { Col, Row } from 'react-bootstrap';
+import { useQuery } from '@tanstack/react-query';
+import Loading from '../../components/loading/Loading';
+import { AnnualReportsPageStrapiContent } from '../../data/interfaces/annual-reports-page/AnnualReportsPageStrapiContent';
+import { getAnnualReportsPageStrapiData } from '../../api/strapiApi';
+import AnnualReportCard from '../../components/annual-report-card/AnnualReportCard';
+
+const AnnualReportsPage: React.FC = () => {
+  const { data, isPending, error } = useQuery<AnnualReportsPageStrapiContent>({
+    queryKey: ['AnnualReports'],
+    queryFn: getAnnualReportsPageStrapiData,
+  });
+
+  if (isPending) return <Loading />;
+  if (error || !data) throw new Error(`Failed to load data: ${error.message}`);
+
+  return (
+    <PageWrapper>
+      <Row>
+        <Col className="text-center mb-4">
+          <h1
+            data-testid="annual-reports-home-page-title"
+            className="fs-1 mt-5 mt-xl-3 fw-bold"
+          >
+            Annual Reports
+          </h1>
+        </Col>
+      </Row>
+      <Row data-testid="annual-reports-grid">
+        {data.data.map((reports, index) => (
+          <Col
+            key={index}
+            xl={4}
+            md={6}
+            xs={12}
+            className="justify-content-center mb-3"
+          >
+            <AnnualReportCard reportData={reports.attributes} />
+          </Col>
+        ))}
+      </Row>
+    </PageWrapper>
+  );
+};
+
+export default AnnualReportsPage;

--- a/src/pages/annual-reports-page/annualReportsPage.test.tsx
+++ b/src/pages/annual-reports-page/annualReportsPage.test.tsx
@@ -1,0 +1,89 @@
+import { screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import {
+  describe,
+  test,
+  expect,
+  beforeEach,
+  afterEach,
+  vi,
+  Mock,
+} from 'vitest';
+import { useQuery } from '@tanstack/react-query';
+import { renderWithProviders } from '../../test/helpers/helpers';
+import AnnualReportsFactory from '../../test/factories/strapi/AnnualReportsFactory';
+import AnnualReportsPage from './AnnualReportsPage';
+
+vi.mock('@tanstack/react-query', async () => {
+  const actual = await vi.importActual('@tanstack/react-query');
+  return {
+    ...actual,
+    useQuery: vi.fn(),
+  };
+});
+
+describe('AnnualReportsPage', () => {
+  const mockData = new AnnualReportsFactory().getMockResponse().data;
+
+  const setup = async () => {
+    (useQuery as Mock).mockReturnValue({
+      data: { data: mockData },
+      isLoading: false,
+      isPending: false,
+      error: null,
+    });
+
+    renderWithProviders(<AnnualReportsPage />);
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Render elements', () => {
+    test('should render the annual reports grid', async () => {
+      await setup();
+      await waitFor(() => {
+        expect(screen.getByTestId('annual-reports-grid')).toBeInTheDocument();
+      });
+    });
+
+    test('should render the correct number of annual report cards', async () => {
+      await setup();
+      await waitFor(() => {
+        expect(screen.getAllByTestId('annual-report-card')).toHaveLength(
+          mockData.length
+        );
+      });
+    });
+
+    test('should render each annual report card with correct data', async () => {
+      await setup();
+      await waitFor(() => {
+        mockData.forEach((report) => {
+          const { title, datePublished, description, link } = report.attributes;
+
+          expect(
+            screen.getByTestId(`annual-report-card-title-${title}`)
+          ).toHaveTextContent(title);
+
+          expect(
+            screen.getByTestId(`annual-report-card-description-${title}`)
+          ).toHaveTextContent(description);
+
+          expect(
+            screen.getByTestId(`annual-report-card-date-${title}`)
+          ).toHaveTextContent(datePublished);
+
+          expect(
+            screen.getByTestId(`annual-report-card-link-${title}`)
+          ).toHaveAttribute('href', link);
+        });
+      });
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+});

--- a/src/routesConfig.tsx
+++ b/src/routesConfig.tsx
@@ -9,6 +9,7 @@ import JobPostPage from './pages/job-post-page/JobPostPage';
 import VolunteeringOpportunitiesHomePage from './pages/volunteer-opportunities-home-page/VolunteeringOpportunitiesHomePage';
 import OurStoryPage from './pages/our-story-page/OurStoryPage';
 import PhilanthropyPage from './pages/philanthropy-page/PhilanthropyPage';
+import AnnualReportsPage from './pages/annual-reports-page/AnnualReportsPage';
 
 const OurMissionVisionAndValuesPage = lazy(
   () =>
@@ -94,6 +95,17 @@ export const routesConfig = [
       <ErrorBoundary>
         <Suspense fallback={<Loading />}>
           <AboutUsPage />
+        </Suspense>
+      </ErrorBoundary>
+    ),
+  },
+
+  {
+    path: '/annual-reports',
+    element: (
+      <ErrorBoundary>
+        <Suspense fallback={<Loading />}>
+          <AnnualReportsPage />
         </Suspense>
       </ErrorBoundary>
     ),

--- a/src/test/factories/strapi/AnnualReportsFactory.ts
+++ b/src/test/factories/strapi/AnnualReportsFactory.ts
@@ -1,0 +1,14 @@
+import annualReportsStrapiResponse from '../../../../fixtures/annualReportsStrapiResponse.json';
+import { AnnualReportStrapiContent } from '../../../data/interfaces/annual-reports-page/AnnualReportStrapiContent';
+import BaseCollectionFactory from '../BaseCollectionFactory';
+
+class AnnualReportsFactory extends BaseCollectionFactory<AnnualReportStrapiContent> {
+  constructor() {
+    super(
+      annualReportsStrapiResponse,
+      `${import.meta.env.VITE_BASE_URL}/api/annual-reports?sort[0]=datePublished:desc&populate[0]=cardImage`
+    );
+  }
+}
+
+export default AnnualReportsFactory;


### PR DESCRIPTION
# Context

- users need a way to see all of the annual reports created by the charity

## Changes proposed in this PR

- added a annual reports page with cards which can link to external storage
